### PR TITLE
fix(xstore): reference count fix

### DIFF
--- a/src/private.h
+++ b/src/private.h
@@ -102,4 +102,4 @@ int openssl_getvalue(lua_State*L, void*p, const char*field);
 
 int openssl_verify_cb(int preverify_ok, X509_STORE_CTX *xctx);
 int openssl_cert_verify_cb(X509_STORE_CTX *xctx,void* u);
-void openssl_xstore_free(X509_STORE* ctx);
+int openssl_xstore_free(X509_STORE* ctx);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -164,10 +164,11 @@ static int openssl_ssl_ctx_gc(lua_State*L)
 {
   SSL_CTX* ctx = CHECK_OBJECT(1, SSL_CTX, "openssl.ssl_ctx");
   if (ctx->cert_store)
-    openssl_xstore_free(ctx->cert_store);
-  if (ctx->references==1)
   {
-    ctx->cert_store = NULL;
+    if (openssl_xstore_free(ctx->cert_store))
+    {
+      ctx->cert_store = NULL;
+    }
   }
   openssl_freevalue(L, ctx);
   SSL_CTX_free(ctx);

--- a/src/xstore.c
+++ b/src/xstore.c
@@ -10,15 +10,19 @@
 
 #define MYNAME "x509.store"
 
-void openssl_xstore_free(X509_STORE* ctx)
+int openssl_xstore_free(X509_STORE* ctx)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
-  if (ctx->references > 1)
-    CRYPTO_add(&ctx->references,-1,CRYPTO_LOCK_X509_STORE);
-  else
-    X509_STORE_free(ctx);
+  int cnt = CRYPTO_add(&ctx->references,-1,CRYPTO_LOCK_X509_STORE);
+  if (cnt > 0)
+  {
+    return 0;
+  }
+  X509_STORE_free(ctx);
+  return 1;
 #else
   X509_STORE_free(ctx);
+  return 1;
 #endif
 }
 


### PR DESCRIPTION
We are seeing a intermittent crash [1] with the free for the x509_store. I think this patch improves the issue.

[1] https://gist.github.com/creationix/01df8f837adc9fd5d265