### PR TITLE
Change. Use lua-lluv to run tests instead of luv.

### DIFF
--- a/test/0.tcp.lua
+++ b/test/0.tcp.lua
@@ -1,44 +1,63 @@
-local _,uv = pcall(require,'luv')
+local ok, uv = pcall(require, 'lluv')
+if not ok then uv = nil end
+
+local lua_spawn do
+local LUA = arg[-1]
+
+local function P(pipe, read)
+  return {
+    stream = pipe,
+    flags = uv.CREATE_PIPE + 
+            (read and uv.READABLE_PIPE or uv.WRITABLE_PIPE)
+  }
+end
+
+lua_spawn = function(f, o, e, c)
+    return uv.spawn({
+        file = LUA, args = {f},
+      stdio = {{}, P(o, false), P(e, false)}
+    }, c)
+end
+end
 
 TestTCP = {}
 if uv then
 function TestEngine:testTCP()
-    print(arg[-1])
-
-    local stdout1 = uv.new_pipe(false)
-    local stderr1 = uv.new_pipe(false)
-    local stdout2 = uv.new_pipe(false)
-    local stderr2 = uv.new_pipe(false)
-
-    local function onread(err, chunk)
-      assert(not err, err)
-      if (chunk) then
-        print(chunk)
-      else
-        print("end")
-      end
+    local function onread(pipe, err, chunk)
+        if err then
+            if err:name() ~= 'EOF' then
+                assert(not err, tostring(err))
+            end
+        end
+        if chunk then
+            print(chunk)
+        else
+            print("end")
+        end
     end
-    local child, pid child, pid = uv.spawn(arg[-1], {
-        args = {"0.tcp_s.lua"},
-        stdio = {nil, stdout1, stderr1}
-    }, function (code, signal)
-        assertEquals(code,1)
-        uv.close(child)
-    end)
-    
-    local child, pid child, pid = uv.spawn(arg[-1], {
-        args = {"0.tcp_c.lua"},
-        stdio = {nil, stdout2, stderr2}
-    }, function (code, signal)
-        assertEquals(code,1)
-        uv.close(child)
-    end)
 
-    uv.read_start(stdout1, onread)
-    uv.read_start(stderr1, onread)
-    uv.read_start(stdout2, onread)
-    uv.read_start(stderr2, onread)
+    local function onclose(child, err, status)
+        if err then return print("Error spawn:", err) end
+        assertEquals(status, 0)
+        child:close()
+    end
+
+    local stdout1 = uv.pipe()
+    local stderr1 = uv.pipe()
+    local stdout2 = uv.pipe()
+    local stderr2 = uv.pipe()
+
+    lua_spawn("0.tcp_s.lua", stdout1, stderr1, onclose)
+
+    lua_spawn("0.tcp_c.lua", stdout2, stderr2, onclose)
+
+    stdout1:start_read(onread)
+    stderr1:start_read(onread)
+    stdout2:start_read(onread)
+    stderr2:start_read(onread)
+
     uv.run()
-    uv.loop_close()
+    uv.close()
 end
 end
+

--- a/test/0.tcp_c.lua
+++ b/test/0.tcp_c.lua
@@ -27,4 +27,4 @@ end
 for i=1,loop do
   mk_connection(host,port)
 end
-os.exit(1)
+os.exit(0)

--- a/test/0.tcp_s.lua
+++ b/test/0.tcp_s.lua
@@ -25,4 +25,4 @@ if srv then
       i = i + 1
   end
 end
-os.exit(1)
+os.exit(0)

--- a/test/8.bio_c.lua
+++ b/test/8.bio_c.lua
@@ -28,7 +28,7 @@ ctx:verify_mode({'peer'},function(arg)
       return true --return false will fail ssh handshake
 end)
 --]]
-print(string.format('CONNECT to %s:%s with %s',host,port,ctx))
+print(string.format('CONNECT to %s:%s with %s',host,port,tostring(ctx)))
 
 function mk_connection(host,port,i)
   local cli = assert(ctx:bio(host..':'..port))
@@ -59,4 +59,4 @@ for i=1,loop do
   mk_connection(host,port,i)
 end
 
-os.exit(1)
+os.exit(0)

--- a/test/8.bio_s.lua
+++ b/test/8.bio_s.lua
@@ -18,7 +18,7 @@ local params = {
 
 local ctx = assert(sslctx.new(params))
 
-print(string.format('Listen at %s:%s with %s',host,port,ctx))
+print(string.format('Listen at %s:%s with %s',host,port,tostring(ctx)))
 
 function ssl_mode()
     local srv = assert(ctx:bio(host..':'..port,true))
@@ -46,4 +46,4 @@ end
 print(pcall(ssl_mode))
 debug.traceback()
 print(openssl.error(true))
-os.exit(1)
+os.exit(0)

--- a/test/8.ssl_c.lua
+++ b/test/8.ssl_c.lua
@@ -29,7 +29,7 @@ ctx:verify_mode({'peer'},function(arg)
       return true --return false will fail ssh handshake
 end)
 
-print(string.format('CONNECT to %s:%s with %s',host,port,ctx))
+print(string.format('CONNECT to %s:%s with %s',host,port,tostring(ctx)))
 
 function mk_connection(host,port,i)
   local cli = assert(bio.connect(host..':'..port,true))
@@ -61,4 +61,4 @@ end
 for i=1,loop do
   mk_connection(host,port,i)
 end
-os.exit(1)
+os.exit(0)

--- a/test/8.ssl_s.lua
+++ b/test/8.ssl_s.lua
@@ -30,7 +30,7 @@ ctx:set_cert_verify(function(arg)
 end)
 --]]
 
-print(string.format('Listen at %s:%s with %s',host,port,ctx))
+print(string.format('Listen at %s:%s with %s',host,port,tostring(ctx)))
 
 function ssl_mode()
     local srv = assert(bio.accept(host..':'..port))
@@ -64,4 +64,4 @@ end
 print(pcall(ssl_mode))
 debug.traceback()
 print(openssl.error(true))
-os.exit(1)
+os.exit(0)


### PR DESCRIPTION
Fix. Tests return 0 in case of success.
Fix. 8. bio/ssl tests pass incorrect type to format function.

All tests pass on WinXP/OpenSSL 1.0.2/lluv 0.1.0

The reason to return `0` as exit code is because if lua occure error in file it also return `1`.
Also this code is not correct
```lua
local _,uv = pcall(require,'luv') -- uv here is library or error message so it always true
...
if uv then
```
Correct for example is
```lua
local ok, uv = pcall(require, 'luv')
if not ok then uv = nil end
...
if uv then
```

Also did you think to install luarocks on travis. This allows you install lluv.
I can PR with my scripts for [travis](https://github.com/moteus/lua-travis-example).