### PR TITLE
Add. `last_error` function that returns error separated by part.

### DIFF
--- a/ldoc/openssl.lua
+++ b/ldoc/openssl.lua
@@ -36,6 +36,16 @@ function list() end
 -- `library name`, `function name` and `reason string` are ASCII text.
 function error() end
 
+--- get last error infomation
+-- @tparam[opt] number error, default use ERR_get_error() return value
+-- @tparam[opt=false] boolean empties the current thread's error queue.
+-- @treturn number errcode
+-- @treturn string reason
+-- @treturn string library name
+-- @treturn string function name
+-- @treturn boolean is this is fatal error
+function last_error() end
+
 --- get random bytes
 -- @tparam number length
 -- @tparam[opt=false] boolean strong true to generate strong randome bytes

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -174,8 +174,13 @@ static LUA_FUNCTION(openssl_last_error)
     lua_pushstring (L, ERR_reason_error_string(val));
     lua_pushstring (L, ERR_lib_error_string   (val));
     lua_pushstring (L, ERR_func_error_string  (val));
+    #ifdef ERR_FATAL_ERROR
     lua_pushboolean(L, ERR_FATAL_ERROR        (val));
     ret = 5;
+    #else
+    ret = 4;
+    #endif
+    
   }
 
   if (clear)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -154,6 +154,36 @@ static LUA_FUNCTION(openssl_error_string)
   return ret;
 }
 
+static LUA_FUNCTION(openssl_last_error)
+{
+  unsigned long val;
+  int clear, ret = 0;
+  if (lua_isnumber(L, 1))
+  {
+    val = (unsigned long)lua_tonumber(L, 1);
+    clear = lua_toboolean(L, 2);
+  } else
+  {
+    val = ERR_get_error();
+    clear = lua_toboolean(L, 1);
+  }
+
+  if (val)
+  {
+    lua_pushinteger(L, val);
+    lua_pushstring (L, ERR_reason_error_string(val));
+    lua_pushstring (L, ERR_lib_error_string   (val));
+    lua_pushstring (L, ERR_func_error_string  (val));
+    lua_pushboolean(L, ERR_FATAL_ERROR        (val));
+    ret = 5;
+  }
+
+  if (clear)
+    ERR_clear_error();
+
+  return ret;
+}
+
 static int openssl_random_load(lua_State*L)
 {
   const char *file = luaL_optstring(L, 1, NULL);
@@ -273,6 +303,7 @@ static const luaL_Reg eay_functions[] =
   {"random",      openssl_random_bytes},
 
   {"error",       openssl_error_string},
+  {"last_error",  openssl_last_error},
 
   {"engine",      openssl_engine},
 


### PR DESCRIPTION
Also this function does not clear error queue by default.
For now I have no strong opinion but I think there should be way to
get all errors. Because of current `error` function already have boolean argument to print
error to stderr I think it not very usable to adds one more optional boolen argument to it.

```Lua
-- print all errors
while true do
  local no, reason = ssl.last_error()
  if not no then break end
  print(reason)
end
-- Get only last error and clear error queue
local err, msg = ssl.last_error(true)
```
