### PR TITLE
Minor fix: Changed ec group parameters to lowercase and fixed naming of curve parameters

### DIFF
--- a/src/ec.c
+++ b/src/ec.c
@@ -126,15 +126,15 @@ static int openssl_ec_group_parse(lua_State*L)
 
   AUXILIAR_SETLSTR(L, -1, "seed", EC_GROUP_get0_seed(group), EC_GROUP_get_seed_len(group));
 
-  X = BN_new();
-  Y = BN_new();
-  P = BN_new();
-  EC_GROUP_get_curve_GFp(group, P, X, Y, ctx);
+  BIGNUM* a = BN_new();
+  BIGNUM* b = BN_new();
+  BIGNUM* p = BN_new();
+  EC_GROUP_get_curve_GFp(group, p, a, b, ctx);
   lua_newtable(L);
   {
-    AUXILIAR_SETOBJECT(L, P, "openssl.bn", -1, "P");
-    AUXILIAR_SETOBJECT(L, X, "openssl.bn", -1, "X");
-    AUXILIAR_SETOBJECT(L, Y, "openssl.bn", -1, "Y");
+    AUXILIAR_SETOBJECT(L, p, "openssl.bn", -1, "p");
+    AUXILIAR_SETOBJECT(L, a, "openssl.bn", -1, "a");
+    AUXILIAR_SETOBJECT(L, b, "openssl.bn", -1, "b");
   }
   lua_setfield(L, -2, "curve");
   BN_CTX_free(ctx);

--- a/src/pkey.c
+++ b/src/pkey.c
@@ -421,28 +421,28 @@ static LUA_FUNCTION(openssl_pkey_new)
       }
       lua_pop(L, 1);
 
-      lua_getfield(L, -1, "D");
+      lua_getfield(L, -1, "d");
       if (!lua_isnil(L, -1))
       {
         d = BN_get(L, -1);
       }
       lua_pop(L, 1);
 
-      lua_getfield(L, -1, "X");
+      lua_getfield(L, -1, "x");
       if (!lua_isnil(L, -1))
       {
         x = BN_get(L, -1);
       }
       lua_pop(L, 1);
 
-      lua_getfield(L, -1, "Y");
+      lua_getfield(L, -1, "y");
       if (!lua_isnil(L, -1))
       {
         y = BN_get(L, -1);
       }
       lua_pop(L, 1);
 
-      lua_getfield(L, -1, "Z");
+      lua_getfield(L, -1, "z");
       if (!lua_isnil(L, -1))
       {
         z = BN_get(L, -1);

--- a/src/pkey.c
+++ b/src/pkey.c
@@ -789,6 +789,11 @@ static LUA_FUNCTION(openssl_pkey_encrypt)
   EVP_PKEY_CTX *ctx = NULL;
   int ret = 0;
 
+  if (pkey->type != EVP_PKEY_RSA && pkey->type != EVP_PKEY_RSA2) {
+    luaL_argerror(L, 2, "EVP_PKEY must be of type RSA or RSA2");
+    return ret;
+  }
+
   if (openssl_pkey_is_private(pkey) == 0)
   {
     ctx = EVP_PKEY_CTX_new(pkey, pkey->engine);
@@ -830,6 +835,11 @@ static LUA_FUNCTION(openssl_pkey_decrypt)
   size_t clen = EVP_PKEY_size(pkey);
   EVP_PKEY_CTX *ctx = NULL;
   int ret = 0;
+
+  if (pkey->type != EVP_PKEY_RSA && pkey->type != EVP_PKEY_RSA2) {
+    luaL_argerror(L, 2, "EVP_PKEY must be of type RSA or RSA2");
+    return ret;
+  }
 
   if (openssl_pkey_is_private(pkey))
   {

--- a/test/ec.lua
+++ b/test/ec.lua
@@ -1,0 +1,34 @@
+local pkey = require'openssl'.pkey
+local unpack = unpack or table.unpack
+
+testEC = {}
+    function testEC:testEC()
+        local nec =  {'ec','prime256v1'}
+        local ec = pkey.new(unpack(nec))
+        local k1 = pkey.get_public(ec)
+        assert(not k1:is_private())
+        local t = k1:parse()
+        assert(t.bits==256)
+        assert(t.type=='ec')
+        assert(t.size==72)
+        local r = t.ec
+        t = r:parse()
+        assertStrContains(tostring(t.pub_key), 'openssl.ec_point')
+        assertStrContains(tostring(t.group), 'openssl.ec_group')
+        local x, y = t.group:affine_coordinates(t.pub_key)
+        assertStrContains(x.version, 'bn library')
+        assertStrContains(y.version, 'bn library')
+        local ec2p = {
+            alg = 'ec',
+            ec_name = t.group:parse().curve_name,
+            x = x,
+            y = y,
+        }
+        local ec2 = pkey.new(ec2p)
+        assert(not ec2:is_private())
+
+        ec2p.d = ec:parse().ec:parse().priv_key
+        local ec2priv = pkey.new(ec2p)
+        assert(ec2priv:is_private())
+
+    end

--- a/test/rsa.lua
+++ b/test/rsa.lua
@@ -5,7 +5,6 @@ testRSA = {}
     function testRSA:testRSA()
         local nrsa =  {'rsa',1024,3}
         local rsa = pkey.new(unpack(nrsa))
-        print(rsa)
         local k1 = pkey.get_public(rsa)
         assert(not k1:is_private())
         local t = k1:parse ()
@@ -16,7 +15,6 @@ testRSA = {}
         t = r:parse()
         t.alg = 'rsa'
         local r2 = pkey.new(t)
-        print('private:',r2:is_private())
         local msg = openssl.random(128-11)
         
         local out = pkey.encrypt(r2,msg)

--- a/test/test.lua
+++ b/test/test.lua
@@ -24,6 +24,7 @@ dofile('7.pkcs12.lua')
 dofile('8.ssl_options.lua')
 dofile('8.ssl.lua')
 dofile('rsa.lua')
+dofile('ec.lua')
 
 --LuaUnit.verbosity = 0
 LuaUnit.run()


### PR DESCRIPTION
* The ec key support returned the group values as a table with uppercase key names.
* The other pkey implementations return a lowercase key.
* The curve parameters are p, a and b. Renamed the key names.
* Adds test for ec keys.
* Displays error if the pkey encrypt/decrypt function is used with a not suitable key