### PR TITLE
looks like ctx:verify_mode expects an int mask

### DIFF
--- a/lib/ssl.lua
+++ b/lib/ssl.lua
@@ -56,11 +56,11 @@ function M.newcontext(params)
             ["fail_if_no_peer_cert"] = "fail"
         }
        
-        local args = {}
-        for i=1,#params.verify do
-            table.insert(args, ssl[luasec_flags[params.verify[i]] or params.verify[i]] or params.verify[i])
+        local verify = 0
+        for i,v in ipairs(params.verify) do
+            verify = verify + (ssl[luasec_flags[v] or v] or v)
         end
-        ctx:verify_mode(unpack(args))
+        ctx:verify_mode(verify)
     end
     if params.options then
         if type(params.options) ~= "table" then


### PR DESCRIPTION
pass an int mask instead of unpacked table to ctx:verify_mode
to better comply with the expectations of ssl.c::openssl_ssl_ctx_verify_mode