### PR TITLE
fix OPENSSL macro finding.

### DIFF
--- a/src/th-lock.c
+++ b/src/th-lock.c
@@ -60,6 +60,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <openssl/lhash.h>
+#include <openssl/crypto.h>
+#include <openssl/buffer.h>
+#include <openssl/x509.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 #ifdef OPENSSL_SYS_WIN32
 #include <windows.h>
 #endif
@@ -76,12 +82,6 @@
 #include <pthread.h>
 #endif
 #endif
-#include <openssl/lhash.h>
-#include <openssl/crypto.h>
-#include <openssl/buffer.h>
-#include <openssl/x509.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
 
 void CRYPTO_thread_setup(void);
 void CRYPTO_thread_cleanup(void);


### PR DESCRIPTION
add #ifdefs after including of openssl files, as OPENSSL_SYS_* macros
are defined in these files.