### PR TITLE
ASN1_GENERALIZEDTIME and ASN1_UTCTIME can be used interchangably

### DIFF
--- a/src/asn1.c
+++ b/src/asn1.c
@@ -1231,7 +1231,11 @@ int openssl_push_asn1object(lua_State* L, const ASN1_OBJECT* obj)
 
 int openssl_push_asn1(lua_State* L, ASN1_STRING* string, int type)
 {
-  if (type == V_ASN1_UNDEF)
+  if ((string->type & V_ASN1_GENERALIZEDTIME) == V_ASN1_GENERALIZEDTIME && type == V_ASN1_UTCTIME)
+    type = V_ASN1_GENERALIZEDTIME;
+  else if ((string->type & V_ASN1_UTCTIME) == V_ASN1_UTCTIME && type == V_ASN1_GENERALIZEDTIME)
+    type = V_ASN1_UTCTIME;
+  else if (type == V_ASN1_UNDEF)
     type = string->type;
   if ((string->type & type) != type)
   {


### PR DESCRIPTION
I was getting "need asn1_string type mismatch" errors with times. Since the two time types can be used this solved the problem.