### PR TITLE
Better handling for different OpenSSL version

### DIFF
--- a/src/csr.c
+++ b/src/csr.c
@@ -41,55 +41,13 @@ static LUA_FUNCTION(openssl_csr_read)
 
 static X509 *X509_REQ_to_X509_ex(X509_REQ *r, int days, EVP_PKEY *pkey, const EVP_MD* md)
 {
-  X509 *ret = NULL;
-  X509_CINF *xi = NULL;
-  X509_NAME *xn;
-  EVP_PKEY *pubkey = NULL;
-  int res;
-
-  if ((ret = X509_new()) == NULL) {
-    X509err(X509_F_X509_REQ_TO_X509, ERR_R_MALLOC_FAILURE);
-    return NULL;
-  }
-
-  /* duplicate the request */
-  xi = ret->cert_info;
-
-  if (sk_X509_ATTRIBUTE_num(r->req_info->attributes) != 0) {
-    if ((xi->version = M_ASN1_INTEGER_new()) == NULL)
-      goto err;
-    if (!ASN1_INTEGER_set(xi->version, 2))
-      goto err;
-    /*-     xi->extensions=ri->attributes; <- bad, should not ever be done
-    ri->attributes=NULL; */
-  }
-
-  xn = X509_REQ_get_subject_name(r);
-  if (X509_set_subject_name(ret, xn) == 0)
-    goto err;
-  if (X509_set_issuer_name(ret, xn) == 0)
-    goto err;
-
-  if (X509_gmtime_adj(xi->validity->notBefore, 0) == NULL)
-    goto err;
-  if (X509_gmtime_adj(xi->validity->notAfter, (long)60 * 60 * 24 * days) ==
-    NULL)
-    goto err;
-
-  pubkey = X509_REQ_get_pubkey(r);
-  res = X509_set_pubkey(ret, pubkey);
-  EVP_PKEY_free(pubkey);
-
+  X509 *ret = X509_REQ_to_X509(r, days, pkey);
   if (!md)
     goto err;
-  if (!res || !X509_sign(ret, pkey, md))
-    goto err;
-  if (0) {
-  err:
-    X509_free(ret);
-    ret = NULL;
-  }
-  return (ret);
+err:
+  X509_free(ret);
+  ret = NULL;
+  return ret;
 }
 
 static LUA_FUNCTION(openssl_csr_to_x509)


### PR DESCRIPTION
X509_REQ_to_X509_ex likely duplicates code from OpenSSL upstream, but the code varies between v1.0.2 and v1.1.0, For better compatibility, I think it is better to wrap X509_REQ_to_X509 function rather than code duplication.