### PR TITLE
fix error messages

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -84,14 +84,14 @@ static int openssl_ssl_ctx_new(lua_State*L)
 #endif
   else
     luaL_error(L, "#1:%s not supported\n"
-               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
+               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n"
                "default is TLSv1",
                meth);
   ciphers = luaL_optstring(L, 2, SSL_DEFAULT_CIPHER_LIST);
   ctx = SSL_CTX_new(method);
   if (!ctx)
     luaL_error(L, "#1:%s not supported\n"
-               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
+               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n"
                "default is TLSv1",
                meth);
   openssl_newvalue(L, ctx);


### PR DESCRIPTION
broken error messages currently only print:
```
ssl.lua:20: #1:default is TLSv1 not supported
Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server
```