### PR TITLE
Removed deprecated OpenSSL functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,11 @@ LIBNAME= $T.so.$V
 CFLAGS		+= $(OPENSSL_CFLAGS) $(LUA_CFLAGS) $(TARGET_FLAGS)
 LDFLAGS		+= -shared $(OPENSSL_LIBS) $(LUA_LIBS)
 # Compilation directives
-WARN_MIN	 = -Wall -Wno-unused-value
+WARN_MIN	 = -Wall -Wno-unused-value -Wno-unused-function
 WARN		 = -Wall
 WARN_MOST	 = $(WARN) -W -Waggregate-return -Wcast-align -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -pedantic
-CFLAGS		+= -g $(WARN_MIN) -DPTHREADS -Ideps -Ideps/lua-compat -Ideps/auxiliar
+CFLAGS		+= $(WARN_MIN) -DPTHREADS -Ideps -Ideps/lua-compat -Ideps/auxiliar
+CFLAGS		+= -DNO_OPENSSL_DEP_METHODS=1
 
 
 OBJS=src/asn1.o deps/auxiliar/auxiliar.o src/bio.o src/cipher.o src/cms.o src/compat.o src/crl.o src/csr.o src/dh.o src/digest.o src/dsa.o \

--- a/src/asn1.c
+++ b/src/asn1.c
@@ -1203,7 +1203,7 @@ static int openssl_asn1group_data(lua_State* L)
 {
   ASN1_STRING* s = CHECK_GROUP(1, ASN1_STRING, "openssl.asn1group");
   if (lua_isnone(L, 2))
-    lua_pushlstring(L, (const char*)ASN1_STRING_data(s), ASN1_STRING_length(s));
+    lua_pushlstring(L, (const char*)ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
   else
   {
     size_t l;
@@ -1275,7 +1275,7 @@ static int openssl_asn1group_tostring(lua_State* L)
     case V_ASN1_INTEGER:
     case V_ASN1_BIT_STRING:
     {
-      BIGNUM *bn = BN_bin2bn((const unsigned char*)ASN1_STRING_data(s), ASN1_STRING_length(s), NULL);
+      BIGNUM *bn = BN_bin2bn((const unsigned char*)ASN1_STRING_get0_data(s), ASN1_STRING_length(s), NULL);
       char* str = BN_bn2hex(bn);
       lua_pushstring(L, str);
       BN_free(bn);
@@ -1283,7 +1283,7 @@ static int openssl_asn1group_tostring(lua_State* L)
       return 1;
     }
     default:
-      lua_pushlstring(L, (const char*) ASN1_STRING_data(s), ASN1_STRING_length(s));
+      lua_pushlstring(L, (const char*)ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
       return 1;
     }
   }

--- a/src/bio.c
+++ b/src/bio.c
@@ -776,21 +776,21 @@ void BIO_info_callback(BIO *bio, int cmd, const char *argp,
   case BIO_CB_READ:
     if (BIO_method_type(bio) & BIO_TYPE_DESCRIPTOR)
       snprintf(p, p_maxlen, "read(%lu,%lu) - %s fd=%lu\n",
-               BIO_number_read(bio), (unsigned long)argi,
-               BIO_method_name(bio), BIO_number_read(bio));
+               (unsigned long)BIO_number_read(bio), (unsigned long)argi,
+               BIO_method_name(bio), (unsigned long)BIO_number_read(bio));
     else
       snprintf(p, p_maxlen, "read(%lu,%lu) - %s\n",
-               BIO_number_read(bio), (unsigned long)argi,
+               (unsigned long)BIO_number_read(bio), (unsigned long)argi,
                BIO_method_name(bio));
     break;
   case BIO_CB_WRITE:
     if (BIO_method_type(bio) & BIO_TYPE_DESCRIPTOR)
       snprintf(p, p_maxlen, "write(%lu,%lu) - %s fd=%lu\n",
-               BIO_number_written(bio), (unsigned long)argi,
-               BIO_method_name(bio), BIO_number_written(bio));
+               (unsigned long)BIO_number_written(bio), (unsigned long)argi,
+               BIO_method_name(bio), (unsigned long)BIO_number_written(bio));
     else
       snprintf(p, p_maxlen, "write(%lu,%lu) - %s\n",
-               BIO_number_written(bio), (unsigned long)argi,
+               (unsigned long)BIO_number_written(bio), (unsigned long)argi,
                BIO_method_name(bio));
     break;
   case BIO_CB_PUTS:

--- a/src/cms.c
+++ b/src/cms.c
@@ -766,7 +766,7 @@ static int openssl_cms_content(lua_State *L)
   if (content && *content)
   {
     ASN1_OCTET_STRING* s = *content;
-    lua_pushlstring(L, (const char*)ASN1_STRING_data(s), ASN1_STRING_length(s));
+    lua_pushlstring(L, (const char*)ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
   }
   else
     lua_pushnil(L);

--- a/src/crl.c
+++ b/src/crl.c
@@ -466,7 +466,7 @@ static LUA_FUNCTION(openssl_crl_lastUpdate)
   X509_CRL *crl = CHECK_OBJECT(1, X509_CRL, "openssl.x509_crl");
   if (lua_isnone(L, 2))
   {
-    ASN1_TIME *tm = X509_CRL_get_lastUpdate(crl);
+    ASN1_TIME const *tm = X509_CRL_get0_lastUpdate(crl);
     PUSH_ASN1_TIME(L, tm);
     return 1;
   }
@@ -499,7 +499,7 @@ static LUA_FUNCTION(openssl_crl_nextUpdate)
   X509_CRL *crl = CHECK_OBJECT(1, X509_CRL, "openssl.x509_crl");
   if (lua_isnone(L, 2))
   {
-    ASN1_TIME *tm = X509_CRL_get_nextUpdate(crl);
+    ASN1_TIME const *tm = X509_CRL_get0_nextUpdate(crl);
     PUSH_ASN1_TIME(L, tm);
     return 1;
   }
@@ -533,9 +533,9 @@ static LUA_FUNCTION(openssl_crl_updateTime)
   X509_CRL *crl = CHECK_OBJECT(1, X509_CRL, "openssl.x509_crl");
   if (lua_isnone(L, 2))
   {
-    ASN1_TIME *ltm, *ntm;
-    ltm = X509_CRL_get_lastUpdate(crl);
-    ntm = X509_CRL_get_nextUpdate(crl);
+    ASN1_TIME const *ltm, *ntm;
+    ltm = X509_CRL_get0_lastUpdate(crl);
+    ntm = X509_CRL_get0_nextUpdate(crl);
     PUSH_ASN1_TIME(L, ltm);
     PUSH_ASN1_TIME(L, ntm);
     return 2;
@@ -784,9 +784,9 @@ static LUA_FUNCTION(openssl_crl_parse)
   openssl_push_xname_asobject(L, X509_CRL_get_issuer(crl));
   lua_setfield(L, -2, "issuer");
 
-  PUSH_ASN1_TIME(L, X509_CRL_get_lastUpdate(crl));
+  PUSH_ASN1_TIME(L, X509_CRL_get0_lastUpdate(crl));
   lua_setfield(L, -2, "lastUpdate");
-  PUSH_ASN1_TIME(L, X509_CRL_get_nextUpdate(crl));
+  PUSH_ASN1_TIME(L, X509_CRL_get0_nextUpdate(crl));
   lua_setfield(L, -2, "nextUpdate");
 
   {

--- a/src/lhash.c
+++ b/src/lhash.c
@@ -94,7 +94,7 @@ LUA_FUNCTION(openssl_lhash_get_string)
   return 1;
 }
 
-static void dump_value_doall_arg(CONF_VALUE *a, lua_State *L)
+static void dump_value_doall_arg(CONF_VALUE const *a, lua_State *L)
 {
   if (a->name)
   {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -310,7 +310,7 @@ static LUA_FUNCTION(openssl_random_bytes)
   }
   else
   {
-    ret = RAND_pseudo_bytes((byte*)buffer, length);
+    ret = RAND_bytes((byte*)buffer, length);
     if (ret == 1)
     {
       lua_pushlstring(L, buffer, length);

--- a/src/pkey.c
+++ b/src/pkey.c
@@ -1129,7 +1129,7 @@ static LUA_FUNCTION(openssl_ec_userId)
     ASN1_OCTET_STRING *s = ASN1_OCTET_STRING_new();
     ret = ENGINE_ctrl(engine, 0x474554, 0x4944, ec, (void(*)(void))s);
     if (ret == 1)
-      lua_pushlstring(L, (const char*) ASN1_STRING_data(s), ASN1_STRING_length(s));
+      lua_pushlstring(L, (const char*) ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
     else
       ret = openssl_pushresult(L, ret);
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -50,6 +50,7 @@ static int openssl_ssl_ctx_new(lua_State*L)
   else if (strcmp(meth, "SSLv23_client") == 0)
     method = SSLv23_client_method();  /* SSLv3 but can rollback to v2 */
 
+#ifndef NO_OPENSSL_DEP_METHODS
   else if (strcmp(meth, "TLSv1_1") == 0)
     method = TLSv1_1_method();    /* TLSv1.0 */
   else if (strcmp(meth, "TLSv1_1_server") == 0)
@@ -77,6 +78,7 @@ static int openssl_ssl_ctx_new(lua_State*L)
     method = DTLSv1_server_method();  /* DTLSv1.0 */
   else if (strcmp(meth, "DTLSv1_client") == 0)
     method = DTLSv1_client_method();  /* DTLSv1.0 */
+#endif
 #ifndef OPENSSL_NO_SSL2
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
   else if (strcmp(meth, "SSLv2") == 0)
@@ -2178,6 +2180,7 @@ static int openssl_ssl_cache_hit(lua_State*L)
   lua_pushboolean(L, ret == 0);
   return 1;
 }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static int openssl_ssl_set_debug(lua_State*L)
 {
   SSL* s = CHECK_OBJECT(1, SSL, "openssl.ssl");
@@ -2185,6 +2188,7 @@ static int openssl_ssl_set_debug(lua_State*L)
   SSL_set_debug(s, debug);
   return 0;
 }
+#endif
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x0090819fL
@@ -2308,7 +2312,9 @@ static luaL_Reg ssl_funcs[] =
 
   {"session_reused", openssl_ssl_session_reused},
 #if OPENSSL_VERSION_NUMBER > 0x10000000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   {"set_debug",   openssl_ssl_set_debug},
+#endif
   {"cache_hit",   openssl_ssl_cache_hit},
   {"renegotiate_abbreviated", openssl_ssl_renegotiate_abbreviated},
 #endif

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -323,7 +323,7 @@ X509_ATTRIBUTE* openssl_new_xattribute(lua_State*L, X509_ATTRIBUTE** a, int idx,
       else
         luaL_argcheck(L, ASN1_STRING_type(s) == arttype, idx, "field value not match type");
     }
-    data = (const char *)ASN1_STRING_data(s);
+    data = (const char *)ASN1_STRING_get0_data(s);
     len  = ASN1_STRING_length(s);
   }
   else

--- a/src/xname.c
+++ b/src/xname.c
@@ -224,7 +224,7 @@ static int openssl_push_xname_entry(lua_State* L, X509_NAME_ENTRY* ne, int obj)
   else
   {
     lua_pushstring(L, OBJ_nid2sn(OBJ_obj2nid(object)));
-    lua_pushlstring(L, (const char*)ASN1_STRING_data(value), ASN1_STRING_length(value));
+    lua_pushlstring(L, (const char*)ASN1_STRING_get0_data(value), ASN1_STRING_length(value));
   }
   lua_settable(L, -3);
   return 1;
@@ -345,7 +345,7 @@ static int openssl_xname_get_text(lua_State*L)
 
   e = X509_NAME_get_entry(xn, lastpos);
   s = X509_NAME_ENTRY_get_data(e);
-  lua_pushlstring(L, (const char *)ASN1_STRING_data(s), ASN1_STRING_length(s));
+  lua_pushlstring(L, (const char *)ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
   lua_pushinteger(L, lastpos);
   return 2;
 };


### PR DESCRIPTION
Still needs more work in src/th-lock.c since some functions have been replaced and the old ones don't pop up as deprecated. Can't / don't have time to deal with that right now.
Tested on Raspberry PI Zero W with OpenSSL 1.1.0f and Lua 5.3.3.
Compiles successfully, but basically no runtime testing done.