### PR TITLE
Modified ssl library cleanup code, fixed all valgrind memoryleaks in libssl

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -412,17 +412,29 @@ static int luaclose_openssl(lua_State *L)
 #if !defined(LIBRESSL_VERSION_NUMBER)
   FIPS_mode_set(0);
 #endif
+
+  ENGINE_cleanup();
+  CONF_modules_free();
+  CONF_modules_unload(1);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+  SSL_COMP_free_compression_methods();
+#endif
+  COMP_zlib_cleanup();
+
+  ERR_free_strings();
+  EVP_cleanup();
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+  ERR_remove_state(0);
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+  ERR_remove_thread_state(NULL);
+#endif
 #if defined(OPENSSL_THREADS)
   CRYPTO_thread_cleanup();
 #endif
   CRYPTO_set_locking_callback(NULL);
   CRYPTO_set_id_callback(NULL);
-
-  ENGINE_cleanup();
-  CONF_modules_unload(1);
-
-  ERR_free_strings();
-  EVP_cleanup();
 
   CRYPTO_cleanup_all_ex_data();
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG


### PR DESCRIPTION
Added some *free() and *cleanup() functions and changed order.
Fixed all valgrind memoryleaks in libssl for me.
Tested on 1.0 and 1.1.