### PR TITLE
Get rid of deprecated APIs

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -8,6 +8,7 @@ openssl.bio is a help object, it is useful, but rarely use.
 */
 #include "openssl.h"
 #include "private.h"
+#include <openssl/bn.h>
 #include <openssl/ssl.h>
 
 #define MYNAME    "bio"

--- a/src/cipher.c
+++ b/src/cipher.c
@@ -747,7 +747,7 @@ static LUA_FUNCTION(openssl_cipher_ctx_info)
   AUXILIAR_SET(L, -1, "block_size", EVP_CIPHER_CTX_block_size(ctx), integer);
   AUXILIAR_SET(L, -1, "key_length", EVP_CIPHER_CTX_key_length(ctx), integer);
   AUXILIAR_SET(L, -1, "iv_length", EVP_CIPHER_CTX_iv_length(ctx), integer);
-  AUXILIAR_SET(L, -1, "flags", EVP_CIPHER_CTX_flags(ctx), integer);
+  AUXILIAR_SET(L, -1, "flags", EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)), integer);
   AUXILIAR_SET(L, -1, "nid", EVP_CIPHER_CTX_nid(ctx), integer);
   AUXILIAR_SET(L, -1, "type", EVP_CIPHER_CTX_mode(ctx), integer);
   AUXILIAR_SET(L, -1, "mode", EVP_CIPHER_CTX_type(ctx), integer);

--- a/src/cms.c
+++ b/src/cms.c
@@ -29,7 +29,7 @@ OpenSSL not give full document about CMS api, so some function will be dangers.
 */
 #include "openssl.h"
 #include "private.h"
-#if OPENSSL_VERSION_NUMBER > 0x00909000L && !defined (LIBRESSL_VERSION_NUMBER)
+#ifndef OPENSSL_NO_CMS
 #include <openssl/cms.h>
 
 #define MYNAME    "cms"
@@ -861,7 +861,7 @@ static luaL_Reg cms_ctx_funs[] =
 
 int luaopen_cms(lua_State *L)
 {
-#if OPENSSL_VERSION_NUMBER > 0x00909000L && !defined (LIBRESSL_VERSION_NUMBER)
+#ifndef OPENSSL_NO_CMS
   ERR_load_CMS_strings();
 
   auxiliar_newclass(L, "openssl.cms",  cms_ctx_funs);

--- a/src/crl.c
+++ b/src/crl.c
@@ -11,6 +11,12 @@ create and manage x509 certificate sign request
 #include "sk.h"
 #include <openssl/x509v3.h>
 
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || \
+	(defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x20700000L))
+#define X509_CRL_set1_nextUpdate X509_CRL_set_nextUpdate
+#define X509_CRL_set1_lastUpdate X509_CRL_set_lastUpdate
+#endif
+
 int   X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b);
 int   X509_CRL_match(const X509_CRL *a, const X509_CRL *b);
 
@@ -235,9 +241,9 @@ static LUA_FUNCTION(openssl_crl_new)
     ntm = ASN1_TIME_new();
     ASN1_TIME_set(ltm, lastUpdate);
     ASN1_TIME_set(ntm, nextUpdate);
-    ret = X509_CRL_set_lastUpdate(crl, ltm);
+    ret = X509_CRL_set1_lastUpdate(crl, ltm);
     if (ret == 1)
-      ret = X509_CRL_set_nextUpdate(crl, ntm);
+      ret = X509_CRL_set1_nextUpdate(crl, ntm);
     ASN1_TIME_free(ltm);
     ASN1_TIME_free(ntm);
   }
@@ -477,7 +483,7 @@ static LUA_FUNCTION(openssl_crl_lastUpdate)
     ASN1_TIME *tm = ASN1_TIME_new();
     ASN1_TIME_set(tm, time);
 
-    ret = X509_CRL_set_lastUpdate(crl, tm);
+    ret = X509_CRL_set1_lastUpdate(crl, tm);
     ASN1_TIME_free(tm);
     return openssl_pushresult(L, ret);
   }
@@ -510,7 +516,7 @@ static LUA_FUNCTION(openssl_crl_nextUpdate)
     ASN1_TIME *tm = ASN1_TIME_new();
     ASN1_TIME_set(tm, time);
 
-    ret = X509_CRL_set_nextUpdate(crl, tm);
+    ret = X509_CRL_set1_nextUpdate(crl, tm);
     ASN1_TIME_free(tm);
     return openssl_pushresult(L, ret);
   }
@@ -563,9 +569,9 @@ static LUA_FUNCTION(openssl_crl_updateTime)
     ASN1_TIME_set(ltm, last);
     ntm = ASN1_TIME_new();
     ASN1_TIME_set(ntm, next);
-    ret = X509_CRL_set_lastUpdate(crl, ltm);
+    ret = X509_CRL_set1_lastUpdate(crl, ltm);
     if (ret == 1)
-      ret = X509_CRL_set_nextUpdate(crl, ntm);
+      ret = X509_CRL_set1_nextUpdate(crl, ntm);
     ASN1_TIME_free(ltm);
     ASN1_TIME_free(ntm);
     openssl_pushresult(L, ret);

--- a/src/dh.c
+++ b/src/dh.c
@@ -46,6 +46,7 @@ static LUA_FUNCTION(openssl_dh_parse)
 
 static int openssl_dh_set_method(lua_State *L)
 {
+#ifndef OPENSSL_NO_ENGINE
   DH* dh = CHECK_OBJECT(1, DH, "openssl.dh");
   ENGINE *e = CHECK_OBJECT(2, ENGINE, "openssl.engine");
   const DH_METHOD *m = ENGINE_get_DH(e);
@@ -54,6 +55,7 @@ static int openssl_dh_set_method(lua_State *L)
     int r = DH_set_method(dh, m);
     return openssl_pushresult(L, r);
   }
+#endif
   return 0;
 }
 

--- a/src/dsa.c
+++ b/src/dsa.c
@@ -45,6 +45,7 @@ static LUA_FUNCTION(openssl_dsa_parse)
 
 static int openssl_dsa_set_method(lua_State *L)
 {
+#ifndef OPENSSL_NO_ENGINE
   DSA* dsa = CHECK_OBJECT(1, DSA, "openssl.dsa");
   ENGINE *e = CHECK_OBJECT(2, ENGINE, "openssl.engine");
   const DSA_METHOD *m = ENGINE_get_DSA(e);
@@ -53,6 +54,7 @@ static int openssl_dsa_set_method(lua_State *L)
     int r = DSA_set_method(dsa, m);
     return openssl_pushresult(L, r);
   }
+#endif
   return 0;
 }
 

--- a/src/ec.c
+++ b/src/ec.c
@@ -612,6 +612,7 @@ static int openssl_ecdh_compute_key(lua_State*L)
 
 static int openssl_ecdsa_set_method(lua_State *L)
 {
+#ifndef OPENSSL_NO_ENGINE
   EC_KEY *ec = CHECK_OBJECT(1, EC_KEY, "openssl.ec_key");
   ENGINE *e = CHECK_OBJECT(2, ENGINE, "openssl.engine");
 #if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -628,6 +629,7 @@ static int openssl_ecdsa_set_method(lua_State *L)
     int r = EC_KEY_set_method(ec, m);
     return openssl_pushresult(L, r);
   }
+#endif
 #endif
   return 0;
 }

--- a/src/engine.c
+++ b/src/engine.c
@@ -51,6 +51,7 @@ static const char* const list[] =
 
 int openssl_engine(lua_State *L)
 {
+#ifndef OPENSSL_NO_ENGINE
   const ENGINE* eng = NULL;
   if (lua_isstring(L, 1))
   {
@@ -77,9 +78,11 @@ int openssl_engine(lua_State *L)
   }
   else
     lua_pushnil(L);
+#endif
   return 1;
 }
 
+#ifndef OPENSSL_NO_ENGINE
 static int openssl_engine_next(lua_State*L)
 {
   ENGINE* eng = CHECK_OBJECT(1, ENGINE, "openssl.engine");
@@ -574,9 +577,12 @@ static luaL_Reg eng_funcs[] =
 
   {NULL,      NULL},
 };
+#endif
 
 int openssl_register_engine(lua_State* L)
 {
+#ifndef OPENSSL_NO_ENGINE
   auxiliar_newclass(L, "openssl.engine", eng_funcs);
+#endif
   return 0;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -428,6 +428,7 @@ static int luaclose_openssl(lua_State *L)
   if(atomic_fetch_sub(&init, 1) > 1)
     return 0;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #if !defined(LIBRESSL_VERSION_NUMBER)
   FIPS_mode_set(0);
 #endif
@@ -474,6 +475,7 @@ static int luaclose_openssl(lua_State *L)
 #endif
 #endif /* OPENSSL_NO_STDIO or OPENSSL_NO_FP_API */
 #endif /* OPENSSL_NO_CRYPTO_MDEBUG */
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L or defined(LIBRESSL_VERSION_NUMBER) */
   return 0;
 }
 
@@ -481,6 +483,7 @@ LUALIB_API int luaopen_openssl(lua_State*L)
 {
   if (atomic_fetch_add(&init, 1) == 0)
   {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #if defined(OPENSSL_THREADS)
     CRYPTO_thread_setup();
 #endif
@@ -493,9 +496,12 @@ LUALIB_API int luaopen_openssl(lua_State*L)
     ERR_load_EVP_strings();
     ERR_load_crypto_strings();
     ERR_load_SSL_strings();
+#endif
 
+#ifndef OPENSSL_NO_ENGINE
     ENGINE_load_dynamic();
     ENGINE_load_openssl();
+#endif
 #ifdef LOAD_ENGINE_CUSTOM
     LOAD_ENGINE_CUSTOM
 #endif

--- a/src/pkey.c
+++ b/src/pkey.c
@@ -15,6 +15,10 @@ pkey module for lua-openssl binding
 #define MYVERSION MYNAME " library for " LUA_VERSION " / Nov 2014 / "\
   "based on OpenSSL " SHLIB_VERSION_NUMBER
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#define EVP_CIPHER_CTX_reset EVP_CIPHER_CTX_init
+#endif
+
 int openssl_pkey_is_private(EVP_PKEY* pkey)
 {
   int ret = 1;
@@ -1363,7 +1367,7 @@ static LUA_FUNCTION(openssl_seal)
       eksl[0] = EVP_PKEY_size(pkeys[0]);
       eks[0] = malloc(eksl[0]);
     }
-    EVP_CIPHER_CTX_init(ctx);
+    EVP_CIPHER_CTX_reset(ctx);
 
     /* allocate one byte extra to make room for \0 */
     len1 = data_len + EVP_CIPHER_block_size(cipher) + 1;
@@ -1443,7 +1447,7 @@ static LUA_FUNCTION(openssl_open)
     len1 = data_len + 1;
     buf = malloc(len1);
 
-    EVP_CIPHER_CTX_init(ctx);
+    EVP_CIPHER_CTX_reset(ctx);
     if (EVP_OpenInit(ctx, cipher, (unsigned char *)ekey, ekey_len, (const unsigned char *)iv, pkey)
         && EVP_OpenUpdate(ctx, buf, &len1, (unsigned char *)data, data_len))
     {
@@ -1622,7 +1626,7 @@ static LUA_FUNCTION(openssl_open_init)
   {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
-    EVP_CIPHER_CTX_init(ctx);
+    EVP_CIPHER_CTX_reset(ctx);
     if (EVP_OpenInit(ctx, cipher, (unsigned char *)ekey, ekey_len, (const unsigned char *)iv, pkey))
     {
       PUSH_OBJECT(ctx, "openssl.evp_cipher_ctx");

--- a/src/pkey.c
+++ b/src/pkey.c
@@ -1115,6 +1115,7 @@ static LUA_FUNCTION(openssl_pkey_get_public)
 /* private useage, and for sm2 */
 static LUA_FUNCTION(openssl_ec_userId)
 {
+#ifndef OPENSSL_NO_ENGINE
   EVP_PKEY* pkey = CHECK_OBJECT(1, EVP_PKEY, "openssl.evp_pkey");
   ENGINE* engine = CHECK_OBJECT(2, ENGINE, "openssl.engine");
   EC_KEY *ec = NULL;
@@ -1146,6 +1147,9 @@ static LUA_FUNCTION(openssl_ec_userId)
     ASN1_OCTET_STRING_set(s, (const unsigned char*) data, l);
     ret = ENGINE_ctrl(engine, 0x534554, 0x4944, ec, (void(*)(void))s);
     return openssl_pushresult(L, ret);
+#else
+  return 0;
+#endif
   }
 }
 

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -171,6 +171,7 @@ static LUA_FUNCTION(openssl_rsa_read)
 
 static int openssl_rsa_set_method(lua_State *L) 
 {
+#ifndef OPENSSL_NO_ENGINE
   RSA* rsa = CHECK_OBJECT(1, RSA, "openssl.rsa");
   ENGINE *e = CHECK_OBJECT(2, ENGINE, "openssl.engine");
   const RSA_METHOD *m = ENGINE_get_RSA(e);
@@ -179,6 +180,7 @@ static int openssl_rsa_set_method(lua_State *L)
     int r = RSA_set_method(rsa, m);
     return openssl_pushresult(L, r);
   }
+#endif
   return 0;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2206,7 +2206,7 @@ static int openssl_ssl_session_reused(lua_State*L)
 static int openssl_ssl_cache_hit(lua_State*L)
 {
   SSL* s = CHECK_OBJECT(1, SSL, "openssl.ssl");
-  int ret = SSL_cache_hit(s);
+  int ret = SSL_session_reused(s);
   lua_pushboolean(L, ret == 0);
   return 1;
 }


### PR DESCRIPTION
When disabling deprecated APIs in OpenSSL, a lot more shows up than the warnings.