### PR TITLE
Adjust X509_ALGOR_cmp check

### DIFF
--- a/src/xalgor.c
+++ b/src/xalgor.c
@@ -59,7 +59,7 @@ static int openssl_xalgor_dup(lua_State* L)
   return 1;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if !(defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x20020000L))
 /***
 compare with other x509_algor object
 @function equals


### PR DESCRIPTION
This was introduced in OPENSSL_VERSION_NUMBER 0x00908000L and removed in
LibreSSL only to be brought back in version 2.1.4. Adjust the check.