### PR TITLE
Latest LuaCrypto had raw defaulting to false.

### DIFF
--- a/lib/crypto.lua
+++ b/lib/crypto.lua
@@ -15,7 +15,6 @@ end
 M.digest = openssl.digest
 local dm = {}
 dm.__call = function(self,alg,msg,raw)
-    raw = raw or true
     return M.digest.digest(alg,msg,raw)
 end
 setmetatable(M.digest,dm)


### PR DESCRIPTION
According to http://mkottman.github.io/luacrypto/manual.html raw defaults to false, just like in openssl.digest.digest.