### PR TITLE
Link crypt32.lib in makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -19,7 +19,7 @@ lib: src\$T.dll
 
 src\$T.dll: $(OBJS)
 	link /DLL /out:src\$T.dll $(OBJS) "$(LUA_LIB)" "$(OPENSSL_LIB)" \
-		ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib 
+		crypt32.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib 
 	IF EXIST src\$T.dll.manifest mt -manifest src\$T.dll.manifest -outputresource:src\$T.dll;2
 
 install: src\$T.dll


### PR DESCRIPTION
closes #212 

Compare with: https://github.com/zhaozg/lua-openssl/commit/5d30d8efa342601d20faf88ba6b10922d75f5a01#diff-af3b638bc2a3e6c650974192a53c7291R25