### PR TITLE
Fix X.509 extension cleanup order in the OpenSSL 1.1 code variant

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -1238,7 +1238,7 @@ static int openssl_x509_extensions(lua_State* L)
 #else
     int i;
     int n = sk_X509_EXTENSION_num(exts);
-    for (i = 0; i < n; i++)
+    for (i = n - 1; i >= 0; i--)
       sk_X509_EXTENSION_delete(exts, i);
     n = sk_X509_EXTENSION_num(others);
     for (i = 0; i < n; i++)


### PR DESCRIPTION
The original loop effectively removed every other extension instead of removing them all, which in turn could result in duplicates when editing extensions.