### PR TITLE
Fix x509 extension editing

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -1228,7 +1228,12 @@ static int openssl_x509_extensions(lua_State* L)
       else
         X509_add_ext(self, ext, -1);
     }
-    sk_X509_EXTENSION_pop_free(others, X509_EXTENSION_free);
+    if (exts!=NULL) {
+      for (i = n - 1; i >= 0; i--)
+        sk_X509_EXTENSION_delete(others, i);
+      sk_X509_EXTENSION_free(others);
+    } else
+      sk_X509_EXTENSION_pop_free(others, X509_EXTENSION_free);
 #endif
     ret = openssl_pushresult(L, 1);
   }

--- a/src/x509.c
+++ b/src/x509.c
@@ -1217,8 +1217,10 @@ static int openssl_x509_extensions(lua_State* L)
 #else
     int i;
     int n = sk_X509_EXTENSION_num(exts);
-    for (i = n - 1; i >= 0; i--)
+    for (i = n - 1; i >= 0; i--) {
+      X509_EXTENSION_free(sk_X509_EXTENSION_value(exts, i));
       sk_X509_EXTENSION_delete(exts, i);
+    }
     n = sk_X509_EXTENSION_num(others);
     for (i = 0; i < n; i++)
     {


### PR DESCRIPTION
Extension values that are to be returned and haven't been copied by X509_add_ext should not be freed. On the other hand, old extension values which are overwritten and deleted should be.