### PR TITLE
fix: registered name for x509 attribute

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -1511,7 +1511,7 @@ int luaopen_x509(lua_State *L)
   openssl_register_xname(L);
   lua_setfield(L, -2, "name");
   openssl_register_xattribute(L);
-  lua_setfield(L, -2, "attribute");
+  lua_setfield(L, -2, "attr");
   openssl_register_xextension(L);
   lua_setfield(L, -2, "extension");
   openssl_register_xstore(L);


### PR DESCRIPTION
Hi, zhaozg,
The [usage](https://zhaozg.github.io/lua-openssl/modules/x509.attr.html) in the documentation does not match the actual encoding. Reference to the documentation and design, it is more appropriate to code as `x509.attr`.
Thank you.