### PR TITLE
Selectively disable GCC diagnostics in ocsp.c

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -104,12 +104,22 @@ static int openssl_ocsp_request_read(lua_State *L)
   BIO *bio = load_bio_object(L, 1);
   int pem = lua_gettop(L) > 1 ? auxiliar_checkboolean(L, 2) : 0;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
 #endif
   OCSP_REQUEST *req = pem ? PEM_read_bio_OCSP_REQUEST(bio, NULL, NULL)
                           : d2i_OCSP_REQUEST_bio(bio, NULL);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
@@ -137,12 +147,22 @@ static int openssl_ocsp_response_read(lua_State *L)
   int pem = lua_gettop(L) > 1 ? auxiliar_checkboolean(L, 2) : 0;
   int ret = 0;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
 #endif
   OCSP_RESPONSE *res = pem ? PEM_read_bio_OCSP_RESPONSE(bio, NULL, NULL)
                            : d2i_OCSP_RESPONSE_bio(bio, NULL);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
GCC 14 fails to compile the library because -Wincompatible-pointer-types is now fatal. Since the warning is already disabled for clang here, might as well include GCC also. Needless to say, this is a workaround and a proper fix would require upstream changes.