### PR TITLE
Add missing objects to Makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -9,7 +9,8 @@ src\ec.obj src\engine.obj src\hmac.obj src\lbn.obj src\lhash.obj src\misc.obj  \
 src\ocsp.obj src\openssl.obj src\ots.obj src\pkcs12.obj src\pkcs7.obj          \
 src\pkey.obj src\rsa.obj src\ssl.obj src\th-lock.obj src\util.obj src\x509.obj \
 src\xattrs.obj src\xexts.obj src\xname.obj src\xstore.obj src\xalgor.obj       \
-src\callback.obj src\srp.obj deps\auxiliar\subsidiar.obj
+src\callback.obj src\srp.obj src\kdf.obj src\param.obj src\mac.obj             \
+deps\auxiliar\subsidiar.obj
 
 
 lib: src\$T.dll


### PR DESCRIPTION
https://github.com/zhaozg/lua-openssl/pull/293 and https://github.com/zhaozg/lua-openssl/pull/283 didn't update Makefile.win

(build failures are preexisting)