### PR TITLE
Implement EC_GROUP and EC_POINT as sub-modules of ec module (#336)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ tmp/
 /src/custom.c
 /src/custom.h
 .nvimrc
+_codeql_build_dir/
+_codeql_detected_source_root

--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,10 @@ CFLAGS		+= $(WARN_MIN) -Ideps -Ideps/lua-compat/c-api -Ideps/auxiliar
 
 OBJS=src/asn1.o deps/auxiliar/auxiliar.o src/bio.o src/cipher.o src/cms.o src/compat.o \
      src/crl.o src/csr.o src/dh.o src/digest.o src/dsa.o src/ec.o src/engine.o         \
-     src/hmac.o src/lbn.o src/lhash.o src/misc.o src/ocsp.o src/openssl.o src/ots.o    \
-     src/pkcs12.o src/pkcs7.o src/pkey.o src/rsa.o src/ssl.o src/th-lock.o src/util.o  \
-     src/x509.o src/xattrs.o src/xexts.o src/xname.o src/xstore.o src/xalgor.o         \
-     src/param.o src/kdf.o                                                             \
+     src/hmac.o src/lbn.o src/lhash.o src/misc.o src/ocsp.o src/openssl.o  \
+     src/ots.o src/pkcs12.o src/pkcs7.o src/pkey.o src/rsa.o src/ssl.o     \
+     src/th-lock.o src/util.o src/x509.o src/xattrs.o src/xexts.o src/xname.o          \
+     src/xstore.o src/xalgor.o src/param.o src/kdf.o                                   \
      src/callback.o src/srp.o src/mac.o deps/auxiliar/subsidiar.o
 
 .PHONY: all install test info doc coveralls asan

--- a/src/ec_util.c
+++ b/src/ec_util.c
@@ -1,0 +1,126 @@
+#include "openssl.h"
+
+int openssl_to_group_asn1_flag(lua_State *L, int i, const char *defval)
+{
+  const char *const flag[] = {"explicit", "named_curve", NULL};
+  int f = luaL_checkoption(L, i, defval, flag);
+  int form = 0;
+
+  if (f == 0)
+    form = 0;
+  else if (f == 1)
+    form = OPENSSL_EC_NAMED_CURVE;
+  else
+    luaL_argerror(L, i, "invalid parameter, only accept 'explicit' or 'named_curve'");
+
+  return form;
+}
+
+int openssl_push_group_asn1_flag(lua_State *L, int flag)
+{
+  if (flag == 0)
+    lua_pushstring(L, "explicit");
+  else if (flag == 1)
+    lua_pushstring(L, "named_curve");
+  else
+    lua_pushnil(L);
+
+  return 1;
+}
+
+point_conversion_form_t openssl_to_point_conversion_form(lua_State *L, int i, const char *defval)
+{
+  const char *options[] = {"compressed", "uncompressed", "hybrid", NULL};
+  int f = luaL_checkoption(L, i, defval, options);
+  point_conversion_form_t form = 0;
+
+  if (f == 0)
+    form = POINT_CONVERSION_COMPRESSED;
+  else if (f == 1)
+    form = POINT_CONVERSION_UNCOMPRESSED;
+  else if (f == 2)
+    form = POINT_CONVERSION_HYBRID;
+  else
+    luaL_argerror(L, i, "invalid parameter, only support 'compressed', 'uncompressed' or 'hybrid'");
+
+  return form;
+}
+
+int openssl_push_point_conversion_form(lua_State *L, point_conversion_form_t form)
+{
+  if (form == POINT_CONVERSION_COMPRESSED)
+    lua_pushstring(L, "compressed");
+  else if (form == POINT_CONVERSION_UNCOMPRESSED)
+    lua_pushstring(L, "uncompressed");
+  else if (form == POINT_CONVERSION_HYBRID)
+    lua_pushstring(L, "hybrid");
+  else
+    lua_pushnil(L);
+
+  return 1;
+}
+
+EC_GROUP *
+openssl_get_ec_group(lua_State *L, int ec_name_idx, int param_enc_idx, int conv_form_idx)
+{
+  int       nid = NID_undef;
+  EC_GROUP *g = NULL;
+  if (lua_isnumber(L, ec_name_idx))
+    nid = lua_tointeger(L, ec_name_idx);
+  else if (lua_isstring(L, ec_name_idx)) {
+    const char *name = luaL_checkstring(L, ec_name_idx);
+    nid = OBJ_txt2nid(name);
+  } else if (lua_isuserdata(L, ec_name_idx)) {
+    if (auxiliar_getclassudata(L, "openssl.evp_pkey", ec_name_idx)) {
+      EVP_PKEY *pkey = CHECK_OBJECT(1, EVP_PKEY, "openssl.evp_pkey");
+      EC_KEY   *ec_key = EVP_PKEY_get1_EC_KEY(pkey);
+      if (ec_key) {
+        g = (EC_GROUP *)EC_KEY_get0_group(ec_key);
+        EC_KEY_free(ec_key);
+      }
+    } else if (auxiliar_getclassudata(L, "openssl.ec_key", ec_name_idx)) {
+      EC_KEY *ec_key = CHECK_OBJECT(1, EC_KEY, "openssl.ec_key");
+      g = (EC_GROUP *)EC_KEY_get0_group(ec_key);
+    }
+    if (g) g = EC_GROUP_dup(g);
+  }
+
+  if (g == NULL && nid != NID_undef) g = EC_GROUP_new_by_curve_name(nid);
+
+  if (g) {
+    if (param_enc_idx) {
+      int form = 0;
+      int type = lua_type(L, param_enc_idx);
+      if (type == LUA_TSTRING) {
+        form = openssl_to_point_conversion_form(L, param_enc_idx, NULL);
+        EC_GROUP_set_point_conversion_form(g, form);
+      } else if (type == LUA_TNUMBER) {
+        form = luaL_checkint(L, param_enc_idx);
+        EC_GROUP_set_point_conversion_form(g, form);
+      } else if (lua_isnoneornil(L, param_enc_idx)) {
+        EC_GROUP_set_point_conversion_form(g, POINT_CONVERSION_UNCOMPRESSED);
+      } else
+        luaL_argerror(L, param_enc_idx, "not accept type of point_conversion_form");
+    } else
+      EC_GROUP_set_point_conversion_form(g, POINT_CONVERSION_UNCOMPRESSED);
+
+    if (conv_form_idx) {
+      int asn1_flag = 0;
+      int type = lua_type(L, conv_form_idx);
+      if (type == LUA_TSTRING) {
+        asn1_flag = openssl_to_group_asn1_flag(L, conv_form_idx, NULL);
+        EC_GROUP_set_asn1_flag(g, asn1_flag);
+      } else if (type == LUA_TNUMBER) {
+        asn1_flag = luaL_checkint(L, conv_form_idx);
+        EC_GROUP_set_asn1_flag(g, asn1_flag);
+      } else if (lua_isnoneornil(L, conv_form_idx)) {
+        EC_GROUP_set_asn1_flag(g, OPENSSL_EC_NAMED_CURVE);
+      } else
+        luaL_argerror(L, conv_form_idx, "not accept type of asn1 flag");
+    } else
+      EC_GROUP_set_asn1_flag(g, OPENSSL_EC_NAMED_CURVE);
+  }
+
+  return g;
+}
+

--- a/src/group.c
+++ b/src/group.c
@@ -1,0 +1,947 @@
+/***
+EC_GROUP module for Lua OpenSSL binding.
+
+This module provides a complete wrapper for OpenSSL's EC_GROUP operations,
+enabling elliptic curve group mathematical operations similar to BIGNUM.
+
+@module ec.group
+@usage
+  group = require('openssl').ec.group
+*/
+
+/* This file is included in ec.c */
+
+#define MYTYPE_GROUP "openssl.ec_group"
+#define MYTYPE_POINT "openssl.ec_point"
+#define MYVERSION_GROUP MYTYPE_GROUP " library for " LUA_VERSION " / Nov 2024"
+
+/***
+Create EC group and generator point from curve specification
+@function new
+@tparam string|table|number curve curve specification (name, parameters, or NID)
+@tparam [opt] string|number form point_conversion_form
+@tparam [opt] string|number flag asn1_flag
+@treturn ec_group the elliptic curve group
+@treturn ec_point the generator point
+@usage
+  group = require('openssl').group
+  g = group.new('prime256v1')
+  g = group.new(415)  -- NID for prime256v1
+*/
+static int
+openssl_group_new(lua_State *L)
+{
+  const EC_GROUP *g = openssl_get_ec_group(L, 1, 2, 3);
+  if (g) {
+    const EC_POINT *p = EC_GROUP_get0_generator(g);
+    p = EC_POINT_dup(p, g);
+    PUSH_OBJECT(g, "openssl.ec_group");
+    PUSH_OBJECT(p, "openssl.ec_point");
+    return 2;
+  }
+  return 0;
+};
+
+/***
+Duplicate an EC_GROUP.
+
+@function dup
+@treturn ec_group duplicated elliptic curve group
+*/
+static int openssl_group_dup(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_GROUP *dup = EC_GROUP_dup(g);
+
+  if (dup) {
+    PUSH_OBJECT(dup, MYTYPE_GROUP);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Get the generator point of the group.
+
+@function generator
+@treturn ec_point generator point of the curve
+*/
+static int openssl_group_generator(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *p = EC_GROUP_get0_generator(g);
+
+  if (p) {
+    p = EC_POINT_dup(p, g);
+    PUSH_OBJECT(p, MYTYPE_POINT);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Get the order of the group.
+
+@function order
+@treturn bn order of the group
+*/
+static int openssl_group_order(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  BIGNUM *order = BN_new();
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_GROUP_get_order(g, order, ctx)) {
+    BN_CTX_free(ctx);
+    PUSH_OBJECT(order, "openssl.bn");
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  BN_free(order);
+  return 0;
+}
+
+/***
+Get the cofactor of the group.
+
+@function cofactor
+@treturn bn cofactor of the group
+*/
+static int openssl_group_cofactor(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  BIGNUM *cofactor = BN_new();
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_GROUP_get_cofactor(g, cofactor, ctx)) {
+    BN_CTX_free(ctx);
+    PUSH_OBJECT(cofactor, "openssl.bn");
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  BN_free(cofactor);
+  return 0;
+}
+
+/***
+Get the degree of the group (field size in bits).
+
+@function degree
+@treturn number degree of the group
+*/
+static int openssl_group_degree(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  lua_pushinteger(L, EC_GROUP_get_degree(g));
+  return 1;
+}
+
+/***
+Get the curve name NID.
+
+@function curve_name
+@treturn number NID of the curve
+*/
+static int openssl_group_curve_name(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  lua_pushinteger(L, EC_GROUP_get_curve_name(g));
+  return 1;
+}
+
+/***
+Get or set the ASN1 flag.
+
+@function asn1_flag
+@tparam[opt] string|number flag ASN1 flag ("explicit" or "named_curve")
+@treturn string|number current ASN1 flag (when getting)
+@treturn ec_group self (when setting)
+*/
+static int openssl_group_asn1_flag(lua_State *L)
+{
+  EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  int asn1_flag;
+
+  if (lua_isnone(L, 2)) {
+    /* Get */
+    asn1_flag = EC_GROUP_get_asn1_flag(g);
+    openssl_push_group_asn1_flag(L, asn1_flag);
+    lua_pushinteger(L, asn1_flag);
+    return 2;
+  } else {
+    /* Set */
+    if (lua_isnumber(L, 2))
+      asn1_flag = luaL_checkint(L, 2);
+    else
+      asn1_flag = openssl_to_group_asn1_flag(L, 2, NULL);
+    EC_GROUP_set_asn1_flag(g, asn1_flag);
+    lua_pushvalue(L, 1);
+    return 1;
+  }
+}
+
+/***
+Get or set the point conversion form.
+
+@function point_conversion_form
+@tparam[opt] string|number form point conversion form ("compressed", "uncompressed", or "hybrid")
+@treturn string|number current conversion form (when getting)
+@treturn ec_group self (when setting)
+*/
+int openssl_group_point_conversion_form(lua_State *L)
+{
+  EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  point_conversion_form_t form;
+
+  if (lua_isnone(L, 2)) {
+    /* Get */
+    form = EC_GROUP_get_point_conversion_form(g);
+    openssl_push_point_conversion_form(L, form);
+    lua_pushinteger(L, form);
+    return 2;
+  } else {
+    /* Set */
+    if (lua_isnumber(L, 2))
+      form = luaL_checkint(L, 2);
+    else
+      form = openssl_to_point_conversion_form(L, 2, NULL);
+    EC_GROUP_set_point_conversion_form(g, form);
+    lua_pushvalue(L, 1);
+    return 1;
+  }
+}
+
+/***
+Get curve parameters (p, a, b).
+
+@function curve
+@treturn table containing p, a, b as BIGNUM objects
+*/
+static int openssl_group_curve(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  BIGNUM *a = BN_new();
+  BIGNUM *b = BN_new();
+  BIGNUM *p = BN_new();
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_GROUP_get_curve(g, p, a, b, ctx)) {
+    BN_CTX_free(ctx);
+    lua_newtable(L);
+    AUXILIAR_SETOBJECT(L, p, "openssl.bn", -1, "p");
+    AUXILIAR_SETOBJECT(L, a, "openssl.bn", -1, "a");
+    AUXILIAR_SETOBJECT(L, b, "openssl.bn", -1, "b");
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  BN_free(a);
+  BN_free(b);
+  BN_free(p);
+  return 0;
+}
+
+/***
+Get the seed value for the group.
+
+@function seed
+@treturn string|nil seed value or nil if not set
+*/
+static int openssl_group_seed(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const unsigned char *seed = EC_GROUP_get0_seed(g);
+  size_t seed_len = EC_GROUP_get_seed_len(g);
+
+  if (seed && seed_len > 0) {
+    lua_pushlstring(L, (const char *)seed, seed_len);
+    return 1;
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Parse the EC group to extract all parameters.
+
+@function parse
+@treturn table containing all group parameters (generator, order, cofactor, degree, curve_name, etc.)
+*/
+static int openssl_group_parse(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *generator = EC_GROUP_get0_generator(group);
+  BN_CTX *ctx = BN_CTX_new();
+  BIGNUM *a, *b, *p, *order, *cofactor;
+
+  lua_newtable(L);
+
+  if (generator) {
+    generator = EC_POINT_dup(generator, group);
+    AUXILIAR_SETOBJECT(L, generator, MYTYPE_POINT, -1, "generator");
+  }
+
+  order = BN_new();
+  EC_GROUP_get_order(group, order, ctx);
+  AUXILIAR_SETOBJECT(L, order, "openssl.bn", -1, "order");
+
+  cofactor = BN_new();
+  EC_GROUP_get_cofactor(group, cofactor, ctx);
+  AUXILIAR_SETOBJECT(L, cofactor, "openssl.bn", -1, "cofactor");
+
+  openssl_push_group_asn1_flag(L, EC_GROUP_get_asn1_flag(group));
+  lua_setfield(L, -2, "asn1_flag");
+
+  AUXILIAR_SET(L, -1, "degree", EC_GROUP_get_degree(group), integer);
+  AUXILIAR_SET(L, -1, "curve_name", EC_GROUP_get_curve_name(group), integer);
+
+  openssl_push_point_conversion_form(L, EC_GROUP_get_point_conversion_form(group));
+  lua_setfield(L, -2, "conversion_form");
+
+  AUXILIAR_SETLSTR(L, -1, "seed", EC_GROUP_get0_seed(group), EC_GROUP_get_seed_len(group));
+
+  a = BN_new();
+  b = BN_new();
+  p = BN_new();
+  EC_GROUP_get_curve(group, p, a, b, ctx);
+  lua_newtable(L);
+  {
+    AUXILIAR_SETOBJECT(L, p, "openssl.bn", -1, "p");
+    AUXILIAR_SETOBJECT(L, a, "openssl.bn", -1, "a");
+    AUXILIAR_SETOBJECT(L, b, "openssl.bn", -1, "b");
+  }
+  lua_setfield(L, -2, "curve");
+  BN_CTX_free(ctx);
+
+  return 1;
+}
+
+/***
+Compare two EC groups for equality.
+
+@function equal
+@tparam ec_group other EC group to compare
+@treturn boolean true if equal, false otherwise
+*/
+int openssl_group_equal(lua_State *L)
+{
+  const EC_GROUP *a = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_GROUP *b = CHECK_OBJECT(2, EC_GROUP, MYTYPE_GROUP);
+
+  lua_pushboolean(L, EC_GROUP_cmp(a, b, NULL) == 0);
+  return 1;
+}
+
+/***
+Free the EC group.
+
+@function free (internal, called by __gc)
+*/
+int openssl_group_free(lua_State *L)
+{
+  EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_GROUP_free(g);
+  return 0;
+}
+
+/***
+Convert EC group to string.
+
+@function tostring (internal, called by __tostring)
+@treturn string string representation of the group
+*/
+static int openssl_group_tostring(lua_State *L)
+{
+  const EC_GROUP *g = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  int nid = EC_GROUP_get_curve_name(g);
+  const char *name = OBJ_nid2sn(nid);
+
+  if (name)
+    lua_pushfstring(L, "ec_group: %s (nid=%d)", name, nid);
+  else
+    lua_pushfstring(L, "ec_group: nid=%d", nid);
+
+  return 1;
+}
+
+/* Helper functions */
+
+
+/***
+Create a new EC point on this group.
+
+@function point_new
+@treturn ec_point new elliptic curve point (at infinity)
+*/
+static int openssl_group_point_new(lua_State *L)
+{
+  EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_POINT *point = EC_POINT_new(group);
+
+  if (point) {
+    PUSH_OBJECT(point, MYTYPE_POINT);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Duplicate an EC point on this group.
+
+@function point_dup
+@tparam ec_point point the EC point to duplicate
+@treturn ec_point duplicated EC point
+*/
+static int openssl_group_point_dup(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  EC_POINT *dup = EC_POINT_dup(point, group);
+
+  if (dup) {
+    PUSH_OBJECT(dup, MYTYPE_POINT);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Compare two EC points for equality.
+
+@function point_equal
+@tparam ec_point a first EC point
+@tparam ec_point b second EC point
+@treturn boolean true if equal, false otherwise
+*/
+int openssl_group_point_equal(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *a = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  const EC_POINT *b = CHECK_OBJECT(3, EC_POINT, MYTYPE_POINT);
+  BN_CTX *ctx = BN_CTX_new();
+  int ret = EC_POINT_cmp(group, a, b, ctx);
+  BN_CTX_free(ctx);
+
+  lua_pushboolean(L, ret == 0);
+  return 1;
+}
+
+/***
+Convert EC point to octet string.
+
+@function point2oct
+@tparam ec_point point the EC point
+@tparam[opt] string form point conversion form ("compressed", "uncompressed", or "hybrid")
+@treturn string|nil octet string representation or nil on failure
+*/
+int openssl_group_point2oct(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  point_conversion_form_t form = lua_isnone(L, 3)
+                                   ? EC_GROUP_get_point_conversion_form(group)
+                                   : openssl_to_point_conversion_form(L, 3, "uncompressed");
+  size_t size = EC_POINT_point2oct(group, point, form, NULL, 0, NULL);
+
+  if (size > 0) {
+    unsigned char *oct = (unsigned char *)OPENSSL_malloc(size);
+    size = EC_POINT_point2oct(group, point, form, oct, size, NULL);
+    if (size > 0) {
+      lua_pushlstring(L, (const char *)oct, size);
+      OPENSSL_free(oct);
+      return 1;
+    }
+    OPENSSL_free(oct);
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Convert octet string to EC point.
+
+@function oct2point
+@tparam string oct octet string representation
+@treturn ec_point|nil the resulting EC point or nil on failure
+*/
+int openssl_group_oct2point(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  size_t size = 0;
+  const unsigned char *oct = (const unsigned char *)luaL_checklstring(L, 2, &size);
+  EC_POINT *point = EC_POINT_new(group);
+
+  if (EC_POINT_oct2point(group, point, oct, size, NULL) == 1) {
+    PUSH_OBJECT(point, MYTYPE_POINT);
+    return 1;
+  }
+
+  EC_POINT_free(point);
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Convert EC point to BIGNUM.
+
+@function point2bn
+@tparam ec_point point the EC point
+@tparam[opt] string form point conversion form ("compressed", "uncompressed", or "hybrid")
+@treturn bn|nil the resulting BIGNUM or nil on failure
+*/
+int openssl_group_point2bn(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  point_conversion_form_t form = lua_isnone(L, 3)
+                                   ? EC_GROUP_get_point_conversion_form(group)
+                                   : openssl_to_point_conversion_form(L, 3, "uncompressed");
+  BIGNUM *bn = EC_POINT_point2bn(group, point, form, NULL, NULL);
+
+  if (bn) {
+    PUSH_OBJECT(bn, "openssl.bn");
+    return 1;
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Convert BIGNUM to EC point.
+
+@function bn2point
+@tparam bn bn the BIGNUM to convert
+@treturn ec_point|nil the resulting EC point or nil on failure
+*/
+int openssl_group_bn2point(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const BIGNUM *bn = CHECK_OBJECT(2, BIGNUM, "openssl.bn");
+  EC_POINT *point = EC_POINT_bn2point(group, bn, NULL, NULL);
+
+  if (point) {
+    PUSH_OBJECT(point, MYTYPE_POINT);
+    return 1;
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Convert EC point to hexadecimal string.
+
+@function point2hex
+@tparam ec_point point the EC point
+@tparam[opt] string form point conversion form ("compressed", "uncompressed", or "hybrid")
+@treturn string|nil hexadecimal string representation or nil on failure
+*/
+int openssl_group_point2hex(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  point_conversion_form_t form = lua_isnone(L, 3)
+                                   ? EC_GROUP_get_point_conversion_form(group)
+                                   : openssl_to_point_conversion_form(L, 3, "uncompressed");
+  char *hex = EC_POINT_point2hex(group, point, form, NULL);
+
+  if (hex) {
+    lua_pushstring(L, hex);
+    OPENSSL_free(hex);
+    return 1;
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Convert hexadecimal string to EC point.
+
+@function hex2point
+@tparam string hex hexadecimal string representation
+@treturn ec_point|nil the resulting EC point or nil on failure
+*/
+int openssl_group_hex2point(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const char *hex = luaL_checkstring(L, 2);
+  EC_POINT *point = EC_POINT_hex2point(group, hex, NULL, NULL);
+
+  if (point) {
+    PUSH_OBJECT(point, MYTYPE_POINT);
+    return 1;
+  }
+
+  lua_pushnil(L);
+  return 1;
+}
+
+/***
+Get or set affine coordinates of an EC point.
+
+@function affine_coordinates
+@tparam ec_group group the EC group
+@tparam[opt] bn x x coordinate (for setting)
+@tparam[opt] bn y y coordinate (for setting)
+@treturn bn x coordinate (when getting)
+@treturn bn y coordinate (when getting)
+*/
+int openssl_group_affine_coordinates(lua_State *L)
+{
+  EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+
+  if (lua_gettop(L) == 2) {
+    /* Get coordinates */
+    BIGNUM *x = BN_new();
+    BIGNUM *y = BN_new();
+
+    if (EC_POINT_get_affine_coordinates(group, point, x, y, NULL) == 1) {
+      PUSH_BN(x);
+      PUSH_BN(y);
+      return 2;
+    } else {
+      BN_free(x);
+      BN_free(y);
+      return 0;
+    }
+  } else {
+    /* Set coordinates */
+    BIGNUM *x = CHECK_OBJECT(3, BIGNUM, "openssl.bn");
+    BIGNUM *y = CHECK_OBJECT(4, BIGNUM, "openssl.bn");
+
+    if (EC_POINT_set_affine_coordinates(group, point, x, y, NULL) == 1) {
+      lua_pushvalue(L, 2);
+      return 1;
+    }
+
+    return luaL_error(L, "EC_POINT_set_affine_coordinates failed");
+  }
+}
+
+/***
+Set EC point to infinity.
+
+@function set_to_infinity
+@tparam ec_group group the EC group
+@treturn ec_point self
+*/
+static int openssl_point_set_to_infinity(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+
+  if (EC_POINT_set_to_infinity(group, point)) {
+    lua_pushvalue(L, 2);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Check if EC point is at infinity.
+
+@function is_at_infinity
+@tparam ec_group group the EC group
+@treturn boolean true if at infinity, false otherwise
+*/
+static int openssl_point_is_at_infinity(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+
+  lua_pushboolean(L, EC_POINT_is_at_infinity(group, point));
+  return 1;
+}
+
+/***
+Check if EC point is on the curve.
+
+@function is_on_curve
+@tparam ec_group group the EC group
+@treturn boolean true if on curve, false otherwise
+*/
+static int openssl_point_is_on_curve(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  BN_CTX *ctx = BN_CTX_new();
+  int ret = EC_POINT_is_on_curve(group, point, ctx);
+  BN_CTX_free(ctx);
+
+  lua_pushboolean(L, ret);
+  return 1;
+}
+
+/***
+Add two EC points.
+
+@function add
+@tparam ec_group group the EC group
+@tparam ec_point a first point
+@tparam ec_point b second point
+@treturn ec_point result point (a + b)
+*/
+static int openssl_point_add(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *a = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  const EC_POINT *b = CHECK_OBJECT(3, EC_POINT, MYTYPE_POINT);
+  EC_POINT *r = EC_POINT_new(group);
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_POINT_add(group, r, a, b, ctx)) {
+    BN_CTX_free(ctx);
+    PUSH_OBJECT(r, MYTYPE_POINT);
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  EC_POINT_free(r);
+  return 0;
+}
+
+/***
+Double an EC point.
+
+@function dbl
+@tparam ec_group group the EC group
+@treturn ec_point result point (2 * point)
+*/
+static int openssl_point_dbl(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  EC_POINT *r = EC_POINT_new(group);
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_POINT_dbl(group, r, point, ctx)) {
+    BN_CTX_free(ctx);
+    PUSH_OBJECT(r, MYTYPE_POINT);
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  EC_POINT_free(r);
+  return 0;
+}
+
+/***
+Invert an EC point.
+
+@function invert
+@tparam ec_group group the EC group
+@treturn ec_point self (inverted)
+*/
+static int openssl_point_invert(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  BN_CTX *ctx = BN_CTX_new();
+
+  if (EC_POINT_invert(group, point, ctx)) {
+    BN_CTX_free(ctx);
+    lua_pushvalue(L, 2);
+    return 1;
+  }
+
+  BN_CTX_free(ctx);
+  return 0;
+}
+
+/***
+Multiply EC point by a scalar.
+
+@function mul
+@tparam ec_group group the EC group
+@tparam bn|number n scalar multiplier
+@tparam[opt] ec_point q optional point for double scalar multiplication
+@tparam[opt] bn m optional second scalar for double scalar multiplication
+@treturn ec_point result point (n * point) or (n * point + m * q)
+*/
+static int openssl_point_mul(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+  const EC_POINT *point = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+  BIGNUM *n = NULL;
+  const EC_POINT *q = NULL;
+  const BIGNUM *m = NULL;
+  EC_POINT *r = EC_POINT_new(group);
+  BN_CTX *ctx = BN_CTX_new();
+  int ret;
+
+  /* Get scalar n */
+  if (lua_isnumber(L, 3)) {
+    n = BN_new();
+    BN_set_word(n, lua_tointeger(L, 3));
+  } else {
+    n = CHECK_OBJECT(3, BIGNUM, "openssl.bn");
+  }
+
+  /* Check for double scalar multiplication */
+  if (!lua_isnone(L, 4)) {
+    q = CHECK_OBJECT(4, EC_POINT, MYTYPE_POINT);
+    m = CHECK_OBJECT(5, BIGNUM, "openssl.bn");
+    ret = EC_POINT_mul(group, r, NULL, point, n, ctx);
+    if (ret) {
+      EC_POINT *temp = EC_POINT_new(group);
+      ret = EC_POINT_mul(group, temp, NULL, q, m, ctx);
+      if (ret) {
+        ret = EC_POINT_add(group, r, r, temp, ctx);
+      }
+      EC_POINT_free(temp);
+    }
+  } else {
+    ret = EC_POINT_mul(group, r, NULL, point, n, ctx);
+  }
+
+  if (lua_isnumber(L, 3)) {
+    BN_free(n);
+  }
+  BN_CTX_free(ctx);
+
+  if (ret) {
+    PUSH_OBJECT(r, MYTYPE_POINT);
+    return 1;
+  }
+
+  EC_POINT_free(r);
+  return 0;
+}
+
+/***
+Generate EC key pair from this group.
+
+@function generate_key
+@treturn ec_key generated EC key object or nil if failed
+*/
+int openssl_group_generate_key(lua_State *L)
+{
+  const EC_GROUP *group = CHECK_OBJECT(1, EC_GROUP, MYTYPE_GROUP);
+
+  EC_KEY *ec = EC_KEY_new();
+  if (ec) {
+    int ret;
+    EC_KEY_set_group(ec, group);
+    ret = EC_KEY_generate_key(ec);
+    if (ret == 1) {
+      PUSH_OBJECT(ec, "openssl.ec_key");
+      return 1;
+    }
+    EC_KEY_free(ec);
+    return openssl_pushresult(L, ret);
+  }
+  return 0;
+}
+
+/***
+List all available elliptic curve names.
+
+@function list
+@treturn table array of curve names and descriptions
+*/
+static int openssl_group_list(lua_State *L)
+{
+  size_t i = 0;
+  size_t crv_len = EC_get_builtin_curves(NULL, 0);
+  EC_builtin_curve *curves = OPENSSL_malloc((int)(sizeof(EC_builtin_curve) * crv_len));
+
+  if (curves == NULL) return 0;
+
+  if (!EC_get_builtin_curves(curves, crv_len)) {
+    OPENSSL_free(curves);
+    return 0;
+  }
+
+  lua_newtable(L);
+  for (i = 0; i < crv_len; i++) {
+    const char *comment;
+    const char *sname;
+    comment = curves[i].comment;
+    sname = OBJ_nid2sn(curves[i].nid);
+    if (comment == NULL) comment = "CURVE DESCRIPTION NOT AVAILABLE";
+    if (sname == NULL) sname = "";
+
+    AUXILIAR_SET(L, -1, sname, comment, string);
+  }
+
+  OPENSSL_free(curves);
+  return 1;
+}
+
+/* Method table */
+static luaL_Reg group_methods[] = {
+  /* Object methods */
+  {"dup",                   openssl_group_dup},
+  {"generator",             openssl_group_generator},
+  {"order",                 openssl_group_order},
+  {"cofactor",              openssl_group_cofactor},
+  {"degree",                openssl_group_degree},
+  {"curve_name",            openssl_group_curve_name},
+  {"asn1_flag",             openssl_group_asn1_flag},
+  {"point_conversion_form", openssl_group_point_conversion_form},
+  {"curve",                 openssl_group_curve},
+  {"seed",                  openssl_group_seed},
+  {"parse",                 openssl_group_parse},
+  {"equal",                 openssl_group_equal},
+
+  /* Point operations on group */
+  {"point_new",             openssl_group_point_new},
+  {"point_dup",             openssl_group_point_dup},
+  {"point_equal",           openssl_group_point_equal},
+  {"point_add",             openssl_point_add},
+  {"point_dbl",             openssl_point_dbl},
+  {"point_invert",          openssl_point_invert},
+  {"point_mul",             openssl_point_mul},
+
+  {"is_at_infinity",        openssl_point_is_at_infinity},
+  {"is_on_curve",           openssl_point_is_on_curve},
+
+  {"point2oct",             openssl_group_point2oct},
+  {"oct2point",             openssl_group_oct2point},
+  {"point2bn",              openssl_group_point2bn},
+  {"bn2point",              openssl_group_bn2point},
+  {"point2hex",             openssl_group_point2hex},
+  {"hex2point",             openssl_group_hex2point},
+
+  {"affine_coordinates",    openssl_group_affine_coordinates},
+  {"set_to_infinity",       openssl_point_set_to_infinity},
+
+  /* EC Key generation */
+  {"generate_key",          openssl_group_generate_key},
+
+  /* Metamethods */
+  {"__eq",                  openssl_group_equal},
+  {"__gc",                  openssl_group_free},
+  {"__tostring",            auxiliar_tostring},
+
+  {NULL,                    NULL}
+};
+
+/* Module functions */
+static luaL_Reg group_functions[] = {
+  {"new",  openssl_group_new},
+  {"list", openssl_group_list},
+
+  {NULL,   NULL}
+};
+
+int
+luaopen_ec_group(lua_State *L) {
+  auxiliar_newclass(L, MYTYPE_GROUP, group_methods);
+
+  lua_newtable(L);
+  luaL_setfuncs(L, group_functions, 0);
+  return 1;
+}

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -93,6 +93,8 @@ int luaopen_ocsp(lua_State *L);
 int luaopen_cms(lua_State *L);
 int luaopen_ssl(lua_State *L);
 int luaopen_ec(lua_State *L);
+int luaopen_group(lua_State *L);
+int luaopen_point(lua_State *L);
 int luaopen_rsa(lua_State *L);
 int luaopen_dsa(lua_State *L);
 int luaopen_dh(lua_State *L);

--- a/src/point.c
+++ b/src/point.c
@@ -1,0 +1,120 @@
+/***
+EC_POINT module for Lua OpenSSL binding.
+
+This module provides a complete wrapper for OpenSSL's EC_POINT operations,
+enabling elliptic curve point mathematical operations.
+
+@module ec.point
+@usage
+  point = require('openssl').ec.point
+*/
+
+/* This file is included in ec.c */
+
+#define MYTYPE_POINT "openssl.ec_point"
+#define MYVERSION_POINT MYTYPE_POINT " library for " LUA_VERSION " / Nov 2024"
+
+/***
+Create a new EC point on a given group.
+
+@function new
+@tparam ec_group group the EC group
+@treturn ec_point new elliptic curve point (at infinity)
+@usage
+  group = require('openssl').group
+  point = require('openssl').point
+  g = group.new('prime256v1')
+  p = point.new(g)
+*/
+
+/***
+Copy one EC point to another.
+
+@function copy
+@tparam ec_point dest destination point
+@tparam ec_point src source point
+@treturn ec_point destination point (self)
+*/
+int openssl_point_copy(lua_State *L)
+{
+  EC_POINT *dest = CHECK_OBJECT(1, EC_POINT, MYTYPE_POINT);
+  const EC_POINT *src = CHECK_OBJECT(2, EC_POINT, MYTYPE_POINT);
+
+  if (EC_POINT_copy(dest, src)) {
+    lua_pushvalue(L, 1);
+    return 1;
+  }
+
+  return 0;
+}
+
+/***
+Free the EC point (internal, called by __gc).
+
+@function free
+*/
+int openssl_point_free(lua_State *L)
+{
+  EC_POINT *point = CHECK_OBJECT(1, EC_POINT, MYTYPE_POINT);
+  EC_POINT_free(point);
+  return 0;
+}
+
+/***
+Convert EC point to string (internal, called by __tostring).
+
+@function tostring
+@treturn string string representation
+*/
+static int openssl_point_tostring(lua_State *L)
+{
+  lua_pushfstring(L, "openssl.ec_point: %p", lua_touserdata(L, 1));
+  return 1;
+}
+
+/* Method table */
+static luaL_Reg point_methods[] = {
+  /* Object methods */
+  {"copy",                 openssl_point_copy},
+
+  /* Metamethods */
+  {"__gc",                 openssl_point_free},
+  {"__tostring",           auxiliar_tostring},
+
+  {NULL,                   NULL}
+};
+
+/* Module functions */
+static luaL_Reg point_functions[] = {
+  {"new",                  openssl_group_point_new},
+  {"dup",                  openssl_group_point_dup},
+  {"equal",                openssl_group_point_equal},
+  {"add",                  openssl_point_add},
+  {"dbl",                  openssl_point_dbl},
+  {"invert",               openssl_point_invert},
+  {"mul",                  openssl_point_mul},
+
+  {"is_at_infinity",       openssl_point_is_at_infinity},
+  {"is_on_curve",          openssl_point_is_on_curve},
+
+  {"point2oct",            openssl_group_point2oct},
+  {"oct2point",            openssl_group_oct2point},
+  {"point2bn",             openssl_group_point2bn},
+  {"bn2point",             openssl_group_bn2point},
+  {"point2hex",            openssl_group_point2hex},
+  {"hex2point",            openssl_group_hex2point},
+
+  {"affine_coordinates",   openssl_group_affine_coordinates},
+  {"set_to_infinity",      openssl_point_set_to_infinity},
+
+  {NULL,                   NULL}
+};
+
+int
+luaopen_ec_point(lua_State *L) {
+  auxiliar_newclass(L, MYTYPE_POINT, point_methods);
+  lua_newtable(L);
+  luaL_setfuncs(L, point_functions, 0);
+  return 1;
+}
+

--- a/src/private.h
+++ b/src/private.h
@@ -320,6 +320,17 @@ int openssl_push_bit_string_bitname(lua_State* L, const BIT_STRING_BITNAME* name
 ASN1_OBJECT* openssl_get_asn1object(lua_State*L, int idx, int retnil);
 EC_GROUP* openssl_get_ec_group(lua_State* L, int ec_name_idx, int param_enc_idx,
                                int conv_form_idx);
+
+
+/* ec_util.c */
+int openssl_to_group_asn1_flag(lua_State *L, int i, const char *defval);
+int openssl_push_group_asn1_flag(lua_State *L, int flag);
+point_conversion_form_t openssl_to_point_conversion_form(lua_State *L, int i, const char *defval);
+int openssl_push_point_conversion_form(lua_State *L, point_conversion_form_t form);
+
+/* point.c affine_coordinates */
+int openssl_point_affine_coordinates(lua_State *L);
+
 int openssl_get_padding(lua_State *L, int idx, const char *defval);
 
 int openssl_register_xname(lua_State*L);

--- a/test/ec.lua
+++ b/test/ec.lua
@@ -72,8 +72,8 @@ function TestEC:TestEC()
   local ec2priv = pkey.new(ec2p)
   assert(ec2priv:is_private())
 
-  assert(openssl.ec.group(ec:parse().ec, 4, 1))
-  assert(openssl.ec.group(ec2, 4, 1))
+  assert(openssl.ec.group.new(ec:parse().ec, 4, 1))
+  assert(openssl.ec.group.new(ec2, 4, 1))
 end
 
 function TestEC:TestPrime256v1()
@@ -98,7 +98,7 @@ end
 
 if openssl.ec then
   local function ECConversionForm(form, flag)
-    local grp, pnt = openssl.ec.group("prime256v1", form, flag)
+    local grp, pnt = openssl.ec.group.new("prime256v1", form, flag)
     assert(grp:asn1_flag() == flag)
     assert(grp:point_conversion_form() == form)
 
@@ -205,7 +205,7 @@ if openssl.ec then
   end
 
   function TestEC:TestIssue262()
-    local grp = openssl.ec.group("prime256v1", "compressed", "named_curve")
+    local grp = openssl.ec.group.new("prime256v1", "compressed", "named_curve")
     local ec = grp:generate_key()
 
     local dgst = openssl.random(32)

--- a/test/group.lua
+++ b/test/group.lua
@@ -1,0 +1,222 @@
+local lu = require("luaunit")
+local openssl = require("openssl")
+local group = openssl.ec.group
+local bn = openssl.bn
+
+TestGroup = {}
+
+function TestGroup:setUp()
+  -- Set up common test groups
+  self.p256 = group.new('prime256v1')
+  self.secp384r1 = group.new('secp384r1')
+  assert(not self.p256 ~= self.secp384r1, "Groups should be different")
+end
+
+function TestGroup:testNew()
+  -- Test creating group from curve name
+  local g = group.new('prime256v1')
+  lu.assertNotNil(g)
+
+  -- Test creating group from NID
+  local g2 = group.new(415) -- NID for prime256v1
+  lu.assertNotNil(g2)
+
+  -- Test invalid curve name
+  lu.assertNil(group.new('invalid_curve'))
+end
+
+function TestGroup:testDup()
+  local g = self.p256
+  local g2 = g:dup()
+  lu.assertNotNil(g2)
+  lu.assertTrue(g:equal(g2))
+end
+
+function TestGroup:testGenerator()
+  local g = self.p256
+  local gen = g:generator()
+  lu.assertNotNil(gen)
+  -- Generator should be a valid EC point
+  lu.assertEquals(type(gen), 'userdata')
+end
+
+function TestGroup:testOrder()
+  local g = self.p256
+  local order = g:order()
+  lu.assertNotNil(order)
+  -- Order should be a BIGNUM
+  lu.assertEquals(type(order), 'userdata')
+  lu.assertStrContains(bn.version, "bn library")
+  -- Prime256v1 order should be 256 bits
+  lu.assertTrue(order:bits() > 255 and order:bits() <= 256)
+end
+
+function TestGroup:testCofactor()
+  local g = self.p256
+  local cofactor = g:cofactor()
+  lu.assertNotNil(cofactor)
+  -- Prime256v1 has cofactor 1
+  lu.assertTrue(cofactor:isone())
+end
+
+function TestGroup:testDegree()
+  local g = self.p256
+  local degree = g:degree()
+  lu.assertEquals(degree, 256)
+
+  local g2 = self.secp384r1
+  lu.assertEquals(g2:degree(), 384)
+end
+
+function TestGroup:testCurveName()
+  local g = self.p256
+  local nid = g:curve_name()
+  lu.assertNotNil(nid)
+  lu.assertEquals(type(nid), 'number')
+  lu.assertEquals(nid, 415) -- NID for prime256v1
+end
+
+function TestGroup:testAsn1Flag()
+  local g = self.p256
+
+  -- Get current flag
+  local flag_str, flag_num = g:asn1_flag()
+  lu.assertNotNil(flag_str)
+  lu.assertNotNil(flag_num)
+
+  -- Set flag by string
+  local g2 = g:asn1_flag('explicit')
+  lu.assertEquals(g2, g) -- Should return self
+  local new_flag = g:asn1_flag()
+  lu.assertEquals(new_flag, 'explicit')
+
+  -- Set flag by number
+  g:asn1_flag(1)
+  local flag = g:asn1_flag()
+  lu.assertEquals(flag, 'named_curve')
+end
+
+function TestGroup:testPointConversionForm()
+  local g = self.p256
+
+  -- Get current form
+  local form_str, form_num = g:point_conversion_form()
+  lu.assertNotNil(form_str)
+  lu.assertNotNil(form_num)
+
+  -- Set form by string
+  g:point_conversion_form('compressed')
+  local new_form = g:point_conversion_form()
+  lu.assertEquals(new_form, 'compressed')
+
+  g:point_conversion_form('uncompressed')
+  local form = g:point_conversion_form()
+  lu.assertEquals(form, 'uncompressed')
+
+  g:point_conversion_form('hybrid')
+  form = g:point_conversion_form()
+  lu.assertEquals(form, 'hybrid')
+end
+
+function TestGroup:testCurve()
+  local g = self.p256
+  local curve = g:curve()
+
+  lu.assertNotNil(curve)
+  lu.assertNotNil(curve.p)
+  lu.assertNotNil(curve.a)
+  lu.assertNotNil(curve.b)
+
+  -- All should be BIGNUMs
+  lu.assertEquals(type(curve.p), 'userdata')
+  lu.assertEquals(type(curve.a), 'userdata')
+  lu.assertEquals(type(curve.b), 'userdata')
+end
+
+function TestGroup:testSeed()
+  local g = self.p256
+  local seed = g:seed()
+  -- Seed may or may not be present depending on the curve
+  -- Just verify it returns something (string or nil)
+  if seed then
+    lu.assertEquals(type(seed), 'string')
+  end
+end
+
+function TestGroup:testParse()
+  local g = self.p256
+  local info = g:parse()
+
+  lu.assertNotNil(info)
+  lu.assertNotNil(info.generator)
+  lu.assertNotNil(info.order)
+  lu.assertNotNil(info.cofactor)
+  lu.assertNotNil(info.degree)
+  lu.assertEquals(info.degree, 256)
+  lu.assertNotNil(info.curve_name)
+  lu.assertEquals(info.curve_name, 415)
+  lu.assertNotNil(info.asn1_flag)
+  lu.assertNotNil(info.conversion_form)
+  lu.assertNotNil(info.curve)
+  lu.assertNotNil(info.curve.p)
+  lu.assertNotNil(info.curve.a)
+  lu.assertNotNil(info.curve.b)
+end
+
+function TestGroup:testEqual()
+  local g1 = group.new('prime256v1')
+  local g2 = group.new('prime256v1')
+  local g3 = group.new('secp384r1')
+
+  lu.assertTrue(g1:equal(g2))
+  lu.assertFalse(g1:equal(g3))
+
+  -- Test __eq metamethod
+  lu.assertTrue(g1 == g2)
+  lu.assertFalse(g1 == g3)
+end
+
+function TestGroup:testList()
+  local curves = group.list()
+  lu.assertNotNil(curves)
+  lu.assertEquals(type(curves), 'table')
+
+  -- Check that some well-known curves are present
+  lu.assertNotNil(curves['prime256v1'])
+  lu.assertNotNil(curves['secp384r1'])
+  lu.assertNotNil(curves['secp521r1'])
+
+  -- Values should be description strings
+  lu.assertEquals(type(curves['prime256v1']), 'string')
+end
+
+function TestGroup:testToString()
+  local g = self.p256
+  local str = tostring(g)
+  lu.assertNotNil(str)
+  lu.assertStrContains(str, 'ec_group')
+end
+
+function TestGroup:testMultipleCurves()
+  -- Test various well-known curves
+  local curves = {
+    'prime256v1',
+    'secp256k1',
+    'secp384r1',
+    'secp521r1'
+  }
+
+  for _, name in ipairs(curves) do
+    local g = group.new(name)
+    lu.assertNotNil(g, "Failed to create group for " .. name)
+
+    -- Verify basic properties
+    local order = g:order()
+    lu.assertNotNil(order)
+    lu.assertTrue(order:bits() > 0)
+
+    local gen = g:generator()
+    lu.assertNotNil(gen)
+  end
+end
+

--- a/test/point.lua
+++ b/test/point.lua
@@ -1,0 +1,345 @@
+local lu = require("luaunit")
+local openssl = require("openssl")
+local group = openssl.ec.group
+local point = openssl.ec.point
+local bn = openssl.bn
+
+TestPoint = {}
+
+function TestPoint:setUp()
+  -- Set up common test group
+  self.g = group.new('prime256v1')
+end
+
+function TestPoint:testNew()
+  local g = self.g
+  local p = point.new(g)
+  lu.assertNotNil(p)
+
+  -- New point should be at infinity
+  lu.assertTrue(point.is_at_infinity(g, p))
+end
+
+function TestPoint:testDup()
+  local g = self.g
+  local gen = g:generator()
+  local p2 = point.dup(g, gen)
+
+  lu.assertNotNil(p2)
+  lu.assertTrue(point.equal(g, gen, p2))
+end
+
+function TestPoint:testCopy()
+  local g = self.g
+  local gen = g:generator()
+  local p = point.new(g)
+
+  p:copy(gen)
+  lu.assertTrue(point.equal(g, p, gen))
+end
+
+function TestPoint:testSetToInfinity()
+  local g = self.g
+  local gen = g:generator()
+
+  lu.assertFalse(point.is_at_infinity(g, gen))
+
+  point.set_to_infinity(g, gen)
+  lu.assertTrue(point.is_at_infinity(g, gen))
+end
+
+function TestPoint:testIsAtInfinity()
+  local g = self.g
+  local p = point.new(g)
+
+  lu.assertTrue(point.is_at_infinity(g, p))
+
+  -- Get generator (not at infinity)
+  local gen = g:generator()
+  lu.assertFalse(point.is_at_infinity(g, gen))
+end
+
+function TestPoint:testIsOnCurve()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Generator should be on the curve
+  lu.assertTrue(point.is_on_curve(g, gen))
+
+  -- Point at infinity should also be "on the curve"
+  local p = point.new(g)
+  lu.assertTrue(point.is_on_curve(g, p))
+end
+
+function TestPoint:testEqual()
+  local g = self.g
+  local gen = g:generator()
+  local p = point.dup(g, gen)
+
+  lu.assertTrue(point.equal(g, gen, p))
+
+  -- Point at infinity
+  local inf1 = point.new(g)
+  local inf2 = point.new(g)
+  lu.assertTrue(point.equal(g, inf1, inf2))
+
+  -- Different points
+  lu.assertFalse(point.equal(g, gen, inf1))
+end
+
+function TestPoint:testAffineCoordinates()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Get coordinates
+  local x, y = point.affine_coordinates(g, gen)
+  lu.assertNotNil(x)
+  lu.assertNotNil(y)
+  lu.assertEquals(type(x), 'userdata')
+  lu.assertEquals(type(y), 'userdata')
+
+  -- Create a new point and set coordinates
+  local p = point.new(g)
+  point.affine_coordinates(g, p, x, y)
+
+  -- Verify it equals the generator
+  lu.assertTrue(point.equal(g, p, gen))
+end
+
+function TestPoint:testAdd()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Add generator to itself
+  local p = point.add(g, gen, gen)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.is_on_curve(g, p))
+
+  -- Adding point to infinity should return the point
+  local inf = point.new(g)
+  local p2 = point.add(g, gen, inf)
+  lu.assertTrue(point.equal(g, p2, gen))
+end
+
+function TestPoint:testDbl()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Double the generator
+  local p = point.dbl(g, gen)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.is_on_curve(g, p))
+
+  -- Should equal generator + generator
+  local p2 = point.add(g, gen, gen)
+  lu.assertTrue(point.equal(g, p, p2))
+end
+
+function TestPoint:testInvert()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Invert the generator
+  local neg_gen = point.dup(g, gen)
+  point.invert(g, neg_gen)
+
+  lu.assertTrue(point.is_on_curve(g, neg_gen))
+
+  -- Adding point and its inverse should give infinity
+  local inf = point.add(g, gen, neg_gen)
+  lu.assertTrue(point.is_at_infinity(g, inf))
+end
+
+function TestPoint:testMul()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Multiply by scalar
+  local n = bn.number(2)
+  local p = point.mul(g, gen, n)
+
+  lu.assertNotNil(p)
+  lu.assertTrue(point.is_on_curve(g, p))
+
+  -- Should equal doubling
+  local p2 = point.dbl(g, gen)
+  lu.assertTrue(point.equal(g, p, p2))
+
+  -- Multiply by order should give infinity
+  local order = g:order()
+  local inf = point.mul(g, gen, order)
+  lu.assertTrue(point.is_at_infinity(g, inf))
+end
+
+function TestPoint:testMulWithNumber()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Multiply by number
+  local p = point.mul(g, gen, 3)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.is_on_curve(g, p))
+
+  -- Should equal gen + gen + gen
+  local p2 = point.add(g, gen, gen)
+  p2 = point.add(g, p2, gen)
+  lu.assertTrue(point.equal(g, p, p2))
+end
+
+function TestPoint:testOct2Point()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Convert to octet string
+  local oct = point.point2oct(g, gen)
+  lu.assertNotNil(oct)
+  lu.assertEquals(type(oct), 'string')
+
+  -- Convert back to point
+  local p = point.oct2point(g, oct)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.equal(g, p, gen))
+end
+
+function TestPoint:testPoint2Oct()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Test different conversion forms
+  local forms = {'compressed', 'uncompressed', 'hybrid'}
+
+  for _, form in ipairs(forms) do
+    local oct = point.point2oct(g, gen, form)
+    lu.assertNotNil(oct, "Failed for form " .. form)
+    lu.assertEquals(type(oct), 'string')
+
+    -- Convert back and verify
+    local p = point.oct2point(g, oct)
+    lu.assertTrue(point.equal(g, p, gen))
+  end
+end
+
+function TestPoint:testBn2Point()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Convert to BIGNUM
+  local bn_val = point.point2bn(g, gen)
+  lu.assertNotNil(bn_val)
+
+  -- Convert back to point
+  local p = point.bn2point(g, bn_val)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.equal(g, p, gen))
+end
+
+function TestPoint:testPoint2Bn()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Test different conversion forms
+  local forms = {'compressed', 'uncompressed'}
+
+  for _, form in ipairs(forms) do
+    local bn_val = point.point2bn(g, gen, form)
+    lu.assertNotNil(bn_val, "Failed for form " .. form)
+
+    -- Convert back and verify
+    local p = point.bn2point(g, bn_val)
+    lu.assertTrue(point.equal(g, p, gen))
+  end
+end
+
+function TestPoint:testHex2Point()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Convert to hex
+  local hex = point.point2hex(g, gen)
+  lu.assertNotNil(hex)
+  lu.assertEquals(type(hex), 'string')
+
+  -- Convert back to point
+  local p = point.hex2point(g, hex)
+  lu.assertNotNil(p)
+  lu.assertTrue(point.equal(g, p, gen))
+end
+
+function TestPoint:testPoint2Hex()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Test different conversion forms
+  local forms = {'compressed', 'uncompressed', 'hybrid'}
+
+  for _, form in ipairs(forms) do
+    local hex = point.point2hex(g, gen, form)
+    lu.assertNotNil(hex, "Failed for form " .. form)
+    lu.assertEquals(type(hex), 'string')
+
+    -- Convert back and verify
+    local p = point.hex2point(g, hex)
+    lu.assertTrue(point.equal(g, p, gen))
+  end
+end
+
+function TestPoint:testToString()
+  local g = self.g
+  local p = point.new(g)
+  local str = tostring(p)
+
+  lu.assertNotNil(str)
+  lu.assertStrContains(str, 'ec_point')
+end
+
+function TestPoint:testScalarMultiplication()
+  local g = self.g
+  local gen = g:generator()
+
+  -- Test various scalar multiplications
+  for i = 1, 5 do
+    local n = bn.number(i)
+    local p = point.mul(g, gen, n)
+
+    lu.assertNotNil(p)
+    lu.assertTrue(point.is_on_curve(g, p))
+
+    -- Verify by adding repeatedly
+    local expected = point.dup(g, gen)
+    for j = 2, i do
+      expected = point.add(g, expected, gen)
+    end
+
+    lu.assertTrue(point.equal(g, p, expected))
+  end
+end
+
+function TestPoint:testPointAdditionCommutative()
+  local g = self.g
+  local gen = g:generator()
+  local two_gen = point.mul(g, gen, 2)
+  local three_gen = point.mul(g, gen, 3)
+
+  -- Test commutativity: P + Q = Q + P
+  local p1 = point.add(g, two_gen, three_gen)
+  local p2 = point.add(g, three_gen, two_gen)
+
+  lu.assertTrue(point.equal(g, p1, p2))
+end
+
+function TestPoint:testPointAdditionAssociative()
+  local g = self.g
+  local gen = g:generator()
+  local two_gen = point.mul(g, gen, 2)
+  local three_gen = point.mul(g, gen, 3)
+
+  -- Test associativity: (P + Q) + R = P + (Q + R)
+  local p1 = point.add(g, gen, two_gen)
+  p1 = point.add(g, p1, three_gen)
+
+  local p2 = point.add(g, two_gen, three_gen)
+  p2 = point.add(g, gen, p2)
+
+  lu.assertTrue(point.equal(g, p1, p2))
+end
+

--- a/test/test.lua
+++ b/test/test.lua
@@ -56,6 +56,8 @@ dofile("issue#185.lua")
 dofile("dh.lua")
 dofile("dsa.lua")
 dofile("rsa.lua")
+dofile("group.lua")
+dofile("point.lua")
 dofile("ec.lua")
 dofile("sm2.lua")
 


### PR DESCRIPTION
* Add EC_GROUP and EC_POINT standalone modules with comprehensive tests
- Added point operations (point_new, point_dup, point_equal, point2oct, oct2point, point2bn, bn2point, point2hex, hex2point, affine_coordinates, generate_key) to EC_GROUP methods in group.c
- Made helper functions in group.c non-static (openssl_to_group_asn1_flag, openssl_push_group_asn1_flag, openssl_to_point_conversion_form, openssl_push_point_conversion_form)
* Added unit test: group.lua and point.lua 
- Updated test files to use openssl.ec.group and openssl.ec.point
