### PR TITLE
fix: the memcpy at ssl in ssl.c

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1008,10 +1008,20 @@ openssl_ssl_ctx_set_alpn_protos(lua_State *L)
         break;
       }
       if (proto_list_len + proto_len >= proto_list_size) {
+        unsigned char *tmp;
         do {
+          if (proto_list_size > (size_t)(-1) / 2) {
+            free(proto_list);
+            return luaL_error(L, "protocol list too large");
+          }
           proto_list_size = proto_list_size * 2;
         } while (proto_list_len + proto_len >= proto_list_size);
-        proto_list = realloc(proto_list, proto_list_size);
+        tmp = realloc(proto_list, proto_list_size);
+        if (tmp == NULL) {
+          free(proto_list);
+          return luaL_error(L, "fail to allocate protocol list");
+        }
+        proto_list = tmp;
       }
       if (proto_list == NULL) {
         err = "fail to allocate protocol list";


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/ssl.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `src/ssl.c:1021` |

**Description**: The memcpy at ssl.c:1021 copies protocol data into a dynamically constructed protocol list buffer using proto_len as the copy length without validating it against the remaining capacity of proto_list. An attacker supplying a crafted protocol name via the Lua ALPN/NPN SSL configuration API can overflow the heap buffer. Additionally, the size arithmetic proto_list_len + proto_len may integer-overflow if both values are near SIZE_MAX, causing an undersized allocation followed by a write overflow.

## Changes
- `src/ssl.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
